### PR TITLE
feat: get active workunit members when create peer reviews

### DIFF
--- a/pkg/handler/project/project.go
+++ b/pkg/handler/project/project.go
@@ -1583,7 +1583,7 @@ func (h *handler) CreateWorkUnit(c *gin.Context) {
 
 	// create work unit member
 	for _, employee := range employees {
-		_, err = h.store.ProjectMember.One(tx.DB(), input.ProjectID, employee.ID.String(), false)
+		pMember, err := h.store.ProjectMember.One(tx.DB(), input.ProjectID, employee.ID.String(), false)
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			l.Error(errs.ErrMemberIsNotActiveInProject, "member is not active in project")
 			c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, done(errs.ErrMemberIsNotActiveInProject), input, ""))
@@ -1595,7 +1595,7 @@ func (h *handler) CreateWorkUnit(c *gin.Context) {
 			WorkUnitID: workUnit.ID,
 			EmployeeID: employee.ID,
 			ProjectID:  model.MustGetUUIDFromString(input.ProjectID),
-			JoinedDate: time.Now(),
+			JoinedDate: *pMember.JoinedDate,
 		}
 		if err := h.store.WorkUnitMember.Create(tx.DB(), &wuMember); err != nil {
 			l.Error(err, "failed to create new work unit member")

--- a/pkg/handler/survey/survey.go
+++ b/pkg/handler/survey/survey.go
@@ -402,7 +402,13 @@ func (h *handler) createPeerReview(db *gorm.DB, req request.CreateSurveyFeedback
 		}
 	}
 
-	peers, err := h.store.WorkUnitMember.GetPeerReviewerInTimeRange(db, &startTime, &endTime)
+	//TODO: will reused this function later
+	// peers, err := h.store.WorkUnitMember.GetPeerReviewerInTimeRange(db, &startTime, &endTime)
+	// if err != nil {
+	// 	return http.StatusInternalServerError, err
+	// }
+
+	peers, err := h.store.WorkUnitMember.GetActivePeerReviewer(db)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/pkg/store/workunitmember/interface.go
+++ b/pkg/store/workunitmember/interface.go
@@ -17,4 +17,5 @@ type IStore interface {
 	One(db *gorm.DB, workUnitID string, employeeID string, status string) (workUnitMember *model.WorkUnitMember, err error)
 	SoftDeleteByWorkUnitID(db *gorm.DB, workUnitID string, employeeID string) (err error)
 	GetPeerReviewerInTimeRange(db *gorm.DB, from *time.Time, to *time.Time) ([]model.WorkUnitPeer, error)
+	GetActivePeerReviewer(db *gorm.DB) ([]model.WorkUnitPeer, error)
 }


### PR DESCRIPTION
#### What's this PR do?

- [x] use `GetActivePeerReviewer` instead of `GetPeerReviewerInTimeRange` to get peer reviewer
