### PR TITLE
chore: fix POST `/engagement-rollup` required `categoryID`

### DIFF
--- a/pkg/handler/engagement/engagement.go
+++ b/pkg/handler/engagement/engagement.go
@@ -113,14 +113,19 @@ func (h *handler) UpsertRollup(c *gin.Context) {
 		)
 		return
 	}
-	categoryID, err := strconv.ParseInt(body.CategoryID, 10, 64)
-	if err != nil {
-		l.Error(err, "unable to parse categoryID to int64")
-		c.JSON(
-			http.StatusBadRequest,
-			view.CreateResponse[any](nil, nil, err, body, ""),
-		)
-		return
+	categoryID := int64(0)
+	if body.CategoryID == "" {
+		categoryID = -1
+	} else {
+		categoryID, err = strconv.ParseInt(body.CategoryID, 10, 64)
+		if err != nil {
+			l.Error(err, "unable to parse categoryID to int64")
+			c.JSON(
+				http.StatusBadRequest,
+				view.CreateResponse[any](nil, nil, err, body, ""),
+			)
+			return
+		}
 	}
 
 	tx, done := h.repo.NewTransaction()

--- a/pkg/handler/engagement/request/request.go
+++ b/pkg/handler/engagement/request/request.go
@@ -7,8 +7,8 @@ var ErrInvalidCount = errors.New("message count or reaction count should be >0")
 type UpsertRollupRequest struct {
 	DiscordUserID string `json:"discordUserID" binding:"required"`
 	LastMessageID string `json:"lastMessageID" binding:"required"`
-	ChannelID     string `json:"channelID"`
-	CategoryID    string `json:"categoryID" binding:"required"`
+	ChannelID     string `json:"channelID" binding:"required"`
+	CategoryID    string `json:"categoryID"`
 	MessageCount  int    `json:"messageCount"`
 	ReactionCount int    `json:"reactionCount"`
 }


### PR DESCRIPTION
#### What's this PR do?

- [x] Fix POST `/engagements/rollup` required `categoryID`

Set default `categoryID` to `-1` if not provided to indicate channels that are not put into a category.

#### What are the relevant Git tickets?-

#### Screenshots (if appropriate)

Sample channels on Dwarves's Discord Server that are not put into a category:

![image](https://github.com/dwarvesf/fortress-api/assets/27758849/0f9314cf-e351-4ef8-9b91-a75528d673c9)

#### Any background context you want to provide? (if appropriate)
