### PR TITLE
chore: set default `categoryID = -1` in `AggregateMessages`

### DIFF
--- a/pkg/handler/engagement/engagement.go
+++ b/pkg/handler/engagement/engagement.go
@@ -26,7 +26,7 @@ type handler struct {
 	config     *config.Config
 
 	// isIndexingMessages is used to make sure that there cannot be
-	// a second AggregateMessages invocation if the first one is not done
+	// a second IndexMessages invocation if the first one is not done
 	isIndexingMessages bool
 }
 


### PR DESCRIPTION
#### What's this PR do?

- [x] Set default `categoryID = -1` in `AggregateMessages`

The fix is needed since:

- On invoking POST `/cronjobs/index-discord-messages`,
- The inner `GetMessagesAfterCursor` might be able to get the messages from channel that does not have a category ready
- That data is passed into `AggregateMessages`, which is raising error on empty `categoryID`.

#### What are the relevant Git tickets?

The fix is similar to #621, where default `categoryID = -1` for POST `/engagements/rollup` is implemented.

#### Screenshots (if appropriate)

![image.png](https://user-images.githubusercontent.com/27758849/247567475-0f9314cf-e351-4ef8-9b91-a75528d673c9.png)

Channel `thang-engagement-c...` does not have a category.

#### Any background context you want to provide? (if appropriate)
