### PR TITLE
feat: add api to get discord msg for delivery metrics

### DIFF
--- a/pkg/handler/deliverymetric/discord_msg.go
+++ b/pkg/handler/deliverymetric/discord_msg.go
@@ -1,0 +1,72 @@
+package deliverymetric
+
+import (
+	"net/http"
+
+	"github.com/dwarvesf/fortress-api/pkg/logger"
+	"github.com/dwarvesf/fortress-api/pkg/service/discord"
+	"github.com/dwarvesf/fortress-api/pkg/view"
+	"github.com/gin-gonic/gin"
+)
+
+func (h *handler) GetWeeklyReportDiscordMsg(c *gin.Context) {
+	l := h.logger.Fields(logger.Fields{
+		"handler": "delivery",
+		"method":  "GetWeeklyReportDiscordMsg",
+	})
+
+	report, err := h.controller.DeliveryMetric.GetWeeklyReport()
+	if err != nil {
+		l.Errorf(err, "failed to get delivery metric weekly report", "body")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	leaderBoard, err := h.controller.DeliveryMetric.GetWeeklyLeaderBoard()
+	if err != nil {
+		l.Errorf(err, "failed to get delivery metric weekly report")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	reportView := view.ToDeliveryMetricWeeklyReport(report)
+	leaderBoardView := view.ToDeliveryMetricLeaderBoard(leaderBoard)
+
+	msg := discord.CreateDeliveryMetricWeeklyReportMessage(reportView, leaderBoardView)
+	c.JSON(http.StatusOK, view.CreateResponse[any](msg, nil, nil, nil, ""))
+}
+
+func (h *handler) GetMonthlyReportDiscordMsg(c *gin.Context) {
+	l := h.logger.Fields(logger.Fields{
+		"handler": "delivery",
+		"method":  "GetMonthlyReportDiscordMsg",
+	})
+
+	report, err := h.controller.DeliveryMetric.GetMonthlyReport()
+	if err != nil {
+		l.Errorf(err, "failed to get delivery metric weekly report")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	currentMonthReport := report.Reports[1]
+	previousMonthReport := report.Reports[2]
+
+	if c.Query("to-now") == "true" {
+		currentMonthReport = report.Reports[0]
+		previousMonthReport = report.Reports[1]
+	}
+
+	leaderBoard, err := h.controller.DeliveryMetric.GetMonthlyLeaderBoard(currentMonthReport.Month)
+	if err != nil {
+		l.Errorf(err, "failed to get delivery metric weekly report")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	reportView := view.ToDeliveryMetricMonthlyReport(currentMonthReport, previousMonthReport)
+	leaderBoardView := view.ToDeliveryMetricLeaderBoard(leaderBoard)
+
+	msg := discord.CreateDeliveryMetricMonthlyReportMessage(reportView, leaderBoardView)
+	c.JSON(http.StatusOK, view.CreateResponse[any](msg, nil, nil, nil, ""))
+}

--- a/pkg/handler/deliverymetric/interface.go
+++ b/pkg/handler/deliverymetric/interface.go
@@ -8,5 +8,8 @@ type IHandler interface {
 	GetWeeklyLeaderBoard(c *gin.Context)
 	GetMonthlyLeaderBoard(c *gin.Context)
 
+	GetWeeklyReportDiscordMsg(c *gin.Context)
+	GetMonthlyReportDiscordMsg(c *gin.Context)
+
 	Sync(c *gin.Context)
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -339,6 +339,10 @@ func loadV1Routes(r *gin.Engine, h *handler.Handler, repo store.DBRepo, s *store
 		deliveryGroup.GET("/report/monthly", amw.WithAuth, pmw.WithPerm(model.PermissionDeliveryMetricsRead), h.DeliveryMetric.GetMonthlyReport)
 		deliveryGroup.GET("/leader-board/weekly", amw.WithAuth, pmw.WithPerm(model.PermissionDeliveryMetricsLeaderBoardRead), h.DeliveryMetric.GetWeeklyLeaderBoard)
 		deliveryGroup.GET("/leader-board/monthly", amw.WithAuth, pmw.WithPerm(model.PermissionDeliveryMetricsLeaderBoardRead), h.DeliveryMetric.GetMonthlyLeaderBoard)
+
+		// API for fortress-discord
+		deliveryGroup.GET("/report/weekly/discord-msg", amw.WithAuth, pmw.WithPerm(model.PermissionDeliveryMetricsRead), h.DeliveryMetric.GetWeeklyReportDiscordMsg)
+		deliveryGroup.GET("/report/monthly/discord-msg", amw.WithAuth, pmw.WithPerm(model.PermissionDeliveryMetricsRead), h.DeliveryMetric.GetMonthlyReportDiscordMsg)
 	}
 
 	/////////////////

--- a/pkg/routes/v1_test.go
+++ b/pkg/routes/v1_test.go
@@ -865,6 +865,18 @@ func Test_loadV1Routes(t *testing.T) {
 				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/deliverymetric.IHandler.GetMonthlyLeaderBoard-fm",
 			},
 		},
+		"/api/v1/delivery-metrics/report/weekly/discord-msg": {
+			"GET": {
+				Method:  "GET",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/deliverymetric.IHandler.GetWeeklyReportDiscordMsg-fm",
+			},
+		},
+		"/api/v1/delivery-metrics/report/monthly/discord-msg": {
+			"GET": {
+				Method:  "GET",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/deliverymetric.IHandler.GetMonthlyReportDiscordMsg-fm",
+			},
+		},
 
 		"/api/v1/public/clients": {
 			"GET": {

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -480,12 +480,12 @@ func calculateTopContributor(topContributors []view.TopContributor) string {
 	return topContributor
 }
 
-func (d *discordClient) DeliveryMetricWeeklyReport(deliveryMetric *view.DeliveryMetricWeeklyReport, leaderBoard *view.WeeklyLeaderBoard, channelID string) (*discordgo.Message, error) {
+func CreateDeliveryMetricWeeklyReportMessage(deliveryMetric *view.DeliveryMetricWeeklyReport, leaderBoard *view.WeeklyLeaderBoard) *discordgo.MessageEmbed {
 	var messageEmbed []*discordgo.MessageEmbedField
 	content := "*Track software team's performance. Encourages competition and collaboration. Optimizes project delivery. Promotes accountability.*\n\n"
 
 	if leaderBoard != nil {
-		leaderBoardStr := getLeaderboardAsString(leaderBoard.Items)
+		leaderBoardStr := getLeaderBoardAsString(leaderBoard.Items)
 		content += "**Leaderboard**\n"
 		content += leaderBoardStr
 		content += "\n\n"
@@ -541,14 +541,19 @@ func (d *discordClient) DeliveryMetricWeeklyReport(deliveryMetric *view.Delivery
 		},
 	}
 
+	return msg
+}
+
+func (d *discordClient) DeliveryMetricWeeklyReport(deliveryMetric *view.DeliveryMetricWeeklyReport, leaderBoard *view.WeeklyLeaderBoard, channelID string) (*discordgo.Message, error) {
+	msg := CreateDeliveryMetricWeeklyReportMessage(deliveryMetric, leaderBoard)
 	return d.SendEmbeddedMessageWithChannel(nil, msg, channelID)
 }
 
-func (d *discordClient) DeliveryMetricMonthlyReport(deliveryMetric *view.DeliveryMetricMonthlyReport, leaderBoard *view.WeeklyLeaderBoard, channelID string) (*discordgo.Message, error) {
+func CreateDeliveryMetricMonthlyReportMessage(deliveryMetric *view.DeliveryMetricMonthlyReport, leaderBoard *view.WeeklyLeaderBoard) *discordgo.MessageEmbed {
 	content := "*Track software team's performance. Encourages competition and collaboration. Optimizes project delivery. Promotes accountability.*\n\n"
 
 	if leaderBoard != nil {
-		leaderBoardStr := getLeaderboardAsString(leaderBoard.Items)
+		leaderBoardStr := getLeaderBoardAsString(leaderBoard.Items)
 		content += "**Leaderboard**\n"
 		content += leaderBoardStr
 		content += "\n\n"
@@ -617,10 +622,15 @@ func (d *discordClient) DeliveryMetricMonthlyReport(deliveryMetric *view.Deliver
 		},
 	}
 
+	return msg
+}
+
+func (d *discordClient) DeliveryMetricMonthlyReport(deliveryMetric *view.DeliveryMetricMonthlyReport, leaderBoard *view.WeeklyLeaderBoard, channelID string) (*discordgo.Message, error) {
+	msg := CreateDeliveryMetricMonthlyReportMessage(deliveryMetric, leaderBoard)
 	return d.SendEmbeddedMessageWithChannel(nil, msg, channelID)
 }
 
-func getLeaderboardAsString(data []view.LeaderBoardItem) string {
+func getLeaderBoardAsString(data []view.LeaderBoardItem) string {
 	emojiMap := map[int]string{
 		1: getEmoji("BADGE1"),
 		2: getEmoji("BADGE2"),
@@ -630,7 +640,7 @@ func getLeaderboardAsString(data []view.LeaderBoardItem) string {
 	}
 	// Sort the data by rank in ascending order
 	var currentRank int
-	var leaderboardString strings.Builder
+	var leaderBoardString strings.Builder
 	for _, employee := range data {
 		rank := employee.Rank
 		if rank > 5 {
@@ -641,16 +651,16 @@ func getLeaderboardAsString(data []view.LeaderBoardItem) string {
 		}
 		if rank != currentRank {
 			if currentRank > 0 {
-				leaderboardString.WriteString("\n")
+				leaderBoardString.WriteString("\n")
 			}
 			currentRank = employee.Rank
-			leaderboardString.WriteString(fmt.Sprintf("%v ", emojiMap[currentRank]))
+			leaderBoardString.WriteString(fmt.Sprintf("%v ", emojiMap[currentRank]))
 		}
 
-		leaderboardString.WriteString(fmt.Sprintf("<@%v> ", employee.DiscordID))
+		leaderBoardString.WriteString(fmt.Sprintf("<@%v> ", employee.DiscordID))
 	}
 
-	return leaderboardString.String()
+	return leaderBoardString.String()
 }
 func (d *discordClient) SendEmbeddedMessageWithChannel(original *model.OriginalDiscordMessage, embed *discordgo.MessageEmbed, channelId string) (*discordgo.Message, error) {
 	msg, err := d.session.ChannelMessageSendEmbed(channelId, normalize(original, embed))


### PR DESCRIPTION
#### What's this PR do?

- [x] add api to get discord msg for delivery metrics for fortress-discord

#### What are the relevant Git tickets?

// Put in link to Git Issue

#### Screenshots (if appropriate)

// Use [Licecap](http://www.cockos.com/licecap/) to share a screencast gif.

#### Any background context you want to provide? (if appropriate)

- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new dependencies which need to be added to?
