### PR TITLE
fix: remove public icy activity log

### DIFF
--- a/pkg/controller/discord/new.go
+++ b/pkg/controller/discord/new.go
@@ -1,28 +1,20 @@
 package discord
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
-
-	"github.com/cenkalti/backoff/v4"
 
 	"github.com/dwarvesf/fortress-api/pkg/config"
 	"github.com/dwarvesf/fortress-api/pkg/logger"
 	"github.com/dwarvesf/fortress-api/pkg/model"
 	"github.com/dwarvesf/fortress-api/pkg/service"
-	"github.com/dwarvesf/fortress-api/pkg/service/mochipay"
-	"github.com/dwarvesf/fortress-api/pkg/service/mochiprofile"
 	"github.com/dwarvesf/fortress-api/pkg/store"
-	"github.com/dwarvesf/fortress-api/pkg/utils"
 )
 
 type IController interface {
 	Log(in model.LogDiscordInput) error
 	PublicAdvanceSalaryLog(in model.LogDiscordInput) error
-	PublishIcyActivityLog() error
 }
 
 type controller struct {
@@ -134,148 +126,6 @@ func (c *controller) PublicAdvanceSalaryLog(in model.LogDiscordInput) error {
 	if err != nil {
 		c.logger.Field("err", err.Error()).Warn("Log failed")
 		return err
-	}
-
-	return nil
-}
-
-func (c *controller) PublishIcyActivityLog() error {
-	logger := c.logger.Field("method", "PublishIcyActivityLog")
-
-	txns := make([]mochipay.TransactionData, 0)
-
-	operation := func() error {
-		resp, err := c.service.MochiPay.GetListTransactions(mochipay.ListTransactionsRequest{
-			Size:         20,
-			Status:       mochipay.TransactionStatusSuccess,
-			ActionList:   []mochipay.TransactionAction{mochipay.TransactionActionVaultTransfer},
-			Type:         mochipay.TransactionTypeReceive,
-			TokenAddress: mochipay.ICYAddress,
-			ChainIDs:     []string{mochipay.BASEChainID},
-			SortBy:       "created_at-", // sort by created_at desc
-		})
-		if err != nil {
-			logger.Error(err, "GetListTransactions failed")
-			return err
-		}
-
-		// reverse txns to send notification from oldest to newest
-		for i := len(resp.Data) - 1; i >= 0; i-- {
-			txns = append(txns, resp.Data[i])
-		}
-
-		return nil
-	}
-
-	// Configure backoff parameters
-	expBackoff := backoff.NewExponentialBackOff()
-	expBackoff.InitialInterval = 2 * time.Second // Initial sleep interval after an error
-	expBackoff.Multiplier = 2                    // Next interval multiplier
-	expBackoff.MaxElapsedTime = 30 * time.Second // Maximum cumulative time for retries, retry 4 times = 2 + 4 + 8 + 16 = 30 seconds
-
-	if err := backoff.Retry(operation, expBackoff); err != nil {
-		logger.Error(err, "GetListTransactions failed after all retry")
-		return err
-	}
-
-	now := time.Now()
-
-	for _, transaction := range txns {
-		// Just publish transaction in 3 minutes
-		if transaction.CreatedAt.Before(now.Add(-3 * time.Minute)) {
-			continue
-		}
-
-		txRawMetadata, err := json.Marshal(transaction.Metadata)
-		if err != nil {
-			logger.Error(err, "Marshal metadata failed")
-			continue
-		}
-
-		var txMetadata mochipay.TransactionMetadata
-		if err := json.Unmarshal(txRawMetadata, &txMetadata); err != nil {
-			logger.Error(err, "Unmarshal transaction metadata failed")
-			continue
-		}
-
-		if txMetadata.VaultRequest == nil {
-			logger.Info("Skip transaction without vault request")
-			continue
-		}
-
-		if !strings.EqualFold(txMetadata.VaultRequest.TokenInfo.Address, mochipay.ICYAddress) ||
-			txMetadata.VaultRequest.TokenInfo.ChainID != mochipay.BASEChainID {
-			logger.Info("Skip transaction without ICY token")
-			continue
-		}
-
-		receiverProfileID := txMetadata.VaultRequest.Receiver
-		receiverProfile, err := c.service.MochiProfile.GetProfile(receiverProfileID)
-		if err != nil {
-			logger.Error(err, "GetProfile failed")
-			continue
-		}
-
-		var receiverDiscordID string
-		for _, assoc := range receiverProfile.AssociatedAccounts {
-			if assoc.Platform == mochiprofile.ProfilePlatformDiscord {
-				receiverDiscordID = assoc.PlatformIdentifier
-				break
-			}
-		}
-
-		if receiverDiscordID == "" {
-			logger.Info("Skip transaction has profile without discord account")
-			continue
-		}
-
-		tokenAmount := txMetadata.VaultRequest.Amount
-
-		if txMetadata.VaultRequest.TokenInfo == nil {
-			logger.Info("Skip transaction without token info")
-			continue
-		}
-
-		tokenDecimal := txMetadata.VaultRequest.TokenInfo.Decimal
-
-		tokenAmountDec := utils.ConvertFromString(tokenAmount, int64(tokenDecimal))
-		tokenAmountUSD := big.NewFloat(0).Mul(tokenAmountDec, big.NewFloat(1.5))
-
-		transferReason := txMetadata.Message
-		if strings.EqualFold(transferReason, mochipay.RewardDefaultMsg) {
-			transferReason = fmt.Sprintf("Reward from **%s** vault", txMetadata.VaultRequest.Name)
-		}
-
-		desc := `
-<:badge5:1058304281775710229> **Receiver:** <@` + receiverDiscordID + `>
-<:money:1080757975649624094> **Amount:** <:ICY:1049620715374133288> ` + tokenAmountDec.String() + ` ($` + tokenAmountUSD.String() + `)
-<:pepenote:885515949673951282> **Reason:** ` + transferReason + `
-
-Head to [note.d.foundation/earn](https://note.d.foundation/earn) to see list of open quests and r&d topics
-		`
-
-		embedMessage := model.DiscordMessageEmbed{
-			Author:      model.DiscordMessageAuthor{},
-			Title:       "<a:money:1049621199468105758> ICY Reward <a:money:1049621199468105758>",
-			Description: desc,
-			URL:         "",
-			Color:       3447003,
-			Fields:      nil,
-			Thumbnail:   model.DiscordMessageImage{},
-			Image:       model.DiscordMessageImage{},
-			Timestamp:   time.Now().Format("2006-01-02T15:04:05.000+07:00"),
-		}
-
-		_, err = c.service.Discord.SendMessage(model.DiscordMessage{
-			Embeds: []model.DiscordMessageEmbed{embedMessage},
-		}, c.config.Discord.Webhooks.ICYPublicLog)
-		if err != nil {
-			logger.Error(err, "Send ICY log activity failed")
-			return err
-		}
-
-		// Sleep 2 seconds each time
-		time.Sleep(2 * time.Second)
 	}
 
 	return nil

--- a/pkg/handler/discord/discord.go
+++ b/pkg/handler/discord/discord.go
@@ -374,20 +374,3 @@ func (h *handler) DeliveryMetricsReport(c *gin.Context) {
 
 	c.JSON(http.StatusOK, view.CreateResponse[any](nil, nil, nil, nil, "ok"))
 }
-
-func (h *handler) PublishIcyActivityLog(c *gin.Context) {
-	l := h.logger.Fields(
-		logger.Fields{
-			"handler": "discord",
-			"method":  "TrackIcyActivity",
-		},
-	)
-
-	if err := h.controller.Discord.PublishIcyActivityLog(); err != nil {
-		l.Error(err, "failed to track icy activity")
-		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
-		return
-	}
-
-	c.JSON(http.StatusOK, view.CreateResponse[any](nil, nil, nil, nil, "ok"))
-}

--- a/pkg/handler/discord/interface.go
+++ b/pkg/handler/discord/interface.go
@@ -8,5 +8,4 @@ type IHandler interface {
 	OnLeaveMessage(c *gin.Context)
 	ReportBraineryMetrics(c *gin.Context)
 	DeliveryMetricsReport(c *gin.Context)
-	PublishIcyActivityLog(c *gin.Context)
 }

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -31,7 +31,6 @@ func loadV1Routes(r *gin.Engine, h *handler.Handler, repo store.DBRepo, s *store
 		cronjob.POST("/delivery-metric-reports", amw.WithAuth, pmw.WithPerm(model.PermissionCronjobExecute), h.Discord.DeliveryMetricsReport)
 		cronjob.POST("/sync-delivery-metrics", amw.WithAuth, pmw.WithPerm(model.PermissionCronjobExecute), h.DeliveryMetric.Sync)
 		cronjob.POST("/sync-conversion-rates", amw.WithAuth, pmw.WithPerm(model.PermissionCronjobExecute), h.ConversionRate.Sync)
-		cronjob.POST("/publish-icy-activity-log", amw.WithAuth, pmw.WithPerm(model.PermissionCronjobExecute), h.Discord.PublishIcyActivityLog)
 	}
 
 	/////////////////

--- a/pkg/routes/v1_test.go
+++ b/pkg/routes/v1_test.go
@@ -932,12 +932,6 @@ func Test_loadV1Routes(t *testing.T) {
 				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/employee.IHandler.CheckSalaryAdvance-fm",
 			},
 		},
-		"/cronjobs/publish-icy-activity-log": {
-			"POST": {
-				Method:  "POST",
-				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/discord.IHandler.PublishIcyActivityLog-fm",
-			},
-		},
 		"/api/v1/discords/salary-advance-report": {
 			"GET": {
 				Method:  "GET",


### PR DESCRIPTION
#### What's this PR do?
Remove Fortress public icy activity log because it is implemented in the Tono bot

![image](https://github.com/dwarvesf/fortress-api/assets/32956772/c78a8f81-e279-4a66-a69f-061b6687ac25)
