### PR TITLE
feat: migrate add table community members

### DIFF
--- a/migrations/schemas/20240513093025-add_table_community_members.sql
+++ b/migrations/schemas/20240513093025-add_table_community_members.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS community_members (
+    id UUID PRIMARY KEY DEFAULT UUID(),
+    discord_id TEXT NOT NULL UNIQUE,
+    discord_username VARCHAR(40) NOT NULL DEFAULT '' UNIQUE,
+    roles TEXT[],
+    employee_id UUID REFERENCES employees(id)
+        ON UPDATE CASCADE
+        ON DELETE NO ACTION
+        DEFAULT NULL,
+    memo_username TEXT NOT NULL DEFAULT '',
+    github_username TEXT NOT NULL DEFAULT '',
+    personal_email TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMP(6)     DEFAULT (now()),
+    updated_at    TIMESTAMP(6)     DEFAULT (now()),
+    deleted_at    TIMESTAMP(6)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS community_members;

--- a/pkg/model/community_member.go
+++ b/pkg/model/community_member.go
@@ -1,0 +1,16 @@
+package model
+
+import "github.com/lib/pq"
+
+// CommunityMember represents information of a community member
+type CommunityMember struct {
+	BaseModel
+
+	DiscordID       string         `json:"discord_id"`
+	DiscordUsername string         `json:"discord_username"`
+	Roles           pq.StringArray `json:"role" gorm:"type:text[]"`
+	EmployeeID      *UUID          `json:"employee_id"`
+	MemoUsername    string         `json:"memo_username"`
+	GithubUsername  string         `json:"github_username"`
+	PersonalEmail   string         `json:"personal_email"`
+}

--- a/pkg/store/communitymember/communitymember.go
+++ b/pkg/store/communitymember/communitymember.go
@@ -1,0 +1,30 @@
+package communitymember
+
+import (
+	"github.com/dwarvesf/fortress-api/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type store struct {
+}
+
+// New creates a new store
+func New() IStore {
+	return &store{}
+}
+
+// ListByUsernames gets a list of community members by given usernames
+func (s *store) ListByUsernames(db *gorm.DB, usernames []string) ([]model.CommunityMember, error) {
+	var cms []model.CommunityMember
+	err := db.Where("discord_username IN (?)", usernames).Find(&cms).Error
+	return cms, err
+}
+
+// Insert inserts a community member on conflict discord_id or discord_username do nothing
+func (s *store) Insert(db *gorm.DB, cm *model.CommunityMember) error {
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "discord_id"}, {Name: "discord_username"}},
+		DoNothing: true,
+	}).Create(cm).Error
+}

--- a/pkg/store/communitymember/interface.go
+++ b/pkg/store/communitymember/interface.go
@@ -1,0 +1,13 @@
+package communitymember
+
+import (
+	"github.com/dwarvesf/fortress-api/pkg/model"
+	"gorm.io/gorm"
+)
+
+type IStore interface {
+	// ListByUsernames gets a list of community members by given usernames
+	ListByUsernames(db *gorm.DB, usernames []string) ([]model.CommunityMember, error)
+	// Insert inserts a community member on conflict discord_id or discord_username do nothing
+	Insert(db *gorm.DB, cm *model.CommunityMember) error
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dwarvesf/fortress-api/pkg/store/chapter"
 	"github.com/dwarvesf/fortress-api/pkg/store/client"
 	"github.com/dwarvesf/fortress-api/pkg/store/clientcontact"
+	"github.com/dwarvesf/fortress-api/pkg/store/communitymember"
 	"github.com/dwarvesf/fortress-api/pkg/store/config"
 	"github.com/dwarvesf/fortress-api/pkg/store/content"
 	"github.com/dwarvesf/fortress-api/pkg/store/conversionrate"
@@ -156,6 +157,7 @@ type Store struct {
 	WorkUnit                workunit.IStore
 	WorkUnitMember          workunitmember.IStore
 	WorkUnitStack           workunitstack.IStore
+	CommunityMember         communitymember.IStore
 }
 
 func New() *Store {
@@ -236,5 +238,6 @@ func New() *Store {
 		WorkUnit:                workunit.New(),
 		WorkUnitMember:          workunitmember.New(),
 		WorkUnitStack:           workunitstack.New(),
+		CommunityMember:         communitymember.New(),
 	}
 }


### PR DESCRIPTION
#### What's this PR do?

Migrate add table `community_members` to store entire DF discord community members, then also migrating table `discord _accounts` into it.