### PR TITLE
feat: separate memo author to new table

### DIFF
--- a/migrations/schemas/20240513105259-add_table_memo_authors_and_unique_memo_link.sql
+++ b/migrations/schemas/20240513105259-add_table_memo_authors_and_unique_memo_link.sql
@@ -1,0 +1,14 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS memo_authors  (
+  memo_log_id UUID NOT NULL REFERENCES memo_logs(id),
+  community_member_id UUID NOT NULL REFERENCES community_members(id),
+  created_at    TIMESTAMP(6)     DEFAULT (now()),
+  PRIMARY KEY (memo_log_id, community_member_id)
+);
+
+ALTER TABLE memo_logs ADD UNIQUE ("url");
+-- +migrate Down
+ALTER TABLE memo_logs DROP CONSTRAINT memo_logs_url_key;
+
+DROP TABLE IF EXISTS memo_authors;

--- a/migrations/schemas/20240513164949-remove_column_memo_logs_authors.sql
+++ b/migrations/schemas/20240513164949-remove_column_memo_logs_authors.sql
@@ -1,0 +1,5 @@
+
+-- +migrate Up
+ALTER TABLE memo_logs DROP COLUMN IF EXISTS authors;
+-- +migrate Down
+ALTER TABLE memo_logs ADD COLUMN authors JSONB;

--- a/pkg/handler/memologs/memo_log.go
+++ b/pkg/handler/memologs/memo_log.go
@@ -54,47 +54,13 @@ func (h *handler) Create(c *gin.Context) {
 	memologs := make([]model.MemoLog, 0)
 	for _, b := range body {
 		publishedAt, _ := time.Parse(time.RFC3339Nano, b.PublishedAt)
-		authors := make([]model.MemoLogAuthor, 0)
-		for _, author := range b.Authors {
-			discordID, found := whitelistedUsers[author]
-			if !found {
-				discordMember, err := h.service.Discord.GetMemberByUsername(author)
-				if err != nil {
-					l.Errorf(err, "[memologs.Create] failed to get discord member", "author", author)
-					continue
-				}
-				discordID = discordMember.User.ID
-			}
 
-			github := ""
-			employeeID := ""
-
-			if discordID != "" {
-				empl, err := h.store.Employee.GetByDiscordID(h.repo.DB(), discordID, true)
-				if err != nil {
-					l.Errorf(err, "[brainerylogs.Create] failed to get employee with discord id %v", discordID)
-				}
-
-				if empl != nil {
-					employeeID = empl.ID.String()
-					githubSA := model.SocialAccounts(empl.SocialAccounts).GetGithub()
-					if githubSA != nil {
-						github = githubSA.AccountID
-					}
-				}
-			}
-
-			authors = append(authors, model.MemoLogAuthor{
-				DiscordID:  discordID,
-				GithubID:   github,
-				EmployeeID: employeeID,
-			})
-		}
+		// TODO: enrich author info and add to `community_members` if not exist
 
 		b := model.MemoLog{
-			Title:       b.Title,
-			URL:         b.URL,
-			Authors:     authors,
+			Title: b.Title,
+			URL:   b.URL,
+			// Authors:     authors, // TODO: change to new authors with community member
 			Tags:        b.Tags,
 			PublishedAt: &publishedAt,
 			Description: b.Description,
@@ -147,25 +113,4 @@ func (h *handler) Sync(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, view.CreateResponse[any](view.ToMemoLog(results), nil, nil, nil, "ok"))
-}
-
-var whitelistedUsers = map[string]string{
-	"thanh":        "790170208228212766",
-	"giangthan":    "797051426437595136",
-	"nikki":        "796991130184187944",
-	"anna":         "575525326181105674",
-	"monotykamary": "184354519726030850",
-	"vhbien":       "421992793582469130",
-	"minhcloud":    "1007496699511570503",
-	"mickwan1234":  "383793994271948803",
-	"hnh":          "567326528216760320",
-	"duy":          "788351441097195520",
-	"huytq":        "361172853326086144",
-	"han":          "151497832853929986",
-	"namtran":      "785756392363524106",
-	"innno_":       "753995829559165044",
-	"dudaka":       "282500790692741121",
-	"tom":          "184354519726030850",
-	"minh":         "1093434004159594496",
-	"jack":         "398384659521863702",
 }

--- a/pkg/model/memo_author.go
+++ b/pkg/model/memo_author.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// MemoAuthor is the join table for memo log and community member
+type MemoAuthor struct {
+	MemoLogID         UUID `gorm:"primaryKey"`
+	CommunityMemberID UUID `gorm:"primaryKey"`
+	CreatedAt         time.Time
+}
+
+func (b *MemoAuthor) BeforeCreate(tx *gorm.DB) (err error) {
+	cols := []clause.Column{}
+	for _, field := range tx.Statement.Schema.PrimaryFields {
+		cols = append(cols, clause.Column{Name: field.DBName})
+	}
+	tx.Statement.AddClause(clause.OnConflict{
+		Columns:   cols,
+		DoNothing: true,
+	})
+
+	return nil
+}

--- a/pkg/store/memolog/memo_log.go
+++ b/pkg/store/memolog/memo_log.go
@@ -16,7 +16,7 @@ func New() IStore {
 
 // Create creates a memo log record in the database
 func (s *store) Create(db *gorm.DB, b []model.MemoLog) ([]model.MemoLog, error) {
-	return b, db.Create(b).Error
+	return b, db.Table("memo_logs").Create(b).Error
 }
 
 // GetLimitByTimeRange gets memo logs in a specific time range, with limit

--- a/pkg/view/memo.go
+++ b/pkg/view/memo.go
@@ -34,13 +34,19 @@ func ToMemoLog(memoLogs []model.MemoLog) []MemoLog {
 	for _, memoLog := range memoLogs {
 		authors := make([]MemoLogAuthor, 0)
 		for _, author := range memoLog.Authors {
+			var employeeID string
+			if author.EmployeeID != nil {
+				employeeID = author.EmployeeID.String()
+			}
+
 			authors = append(authors, MemoLogAuthor{
-				EmployeeID: author.EmployeeID,
-				GithubID:   author.GithubID,
+				EmployeeID: employeeID,
+				GithubID:   author.GithubUsername,
 				DiscordID:  author.DiscordID,
 			})
 		}
 
+		// TODO: change response following the new model
 		rs = append(rs, MemoLog{
 			ID:          memoLog.ID.String(),
 			Title:       memoLog.Title,


### PR DESCRIPTION
#### What's this PR do?

After adding table `community_members`, now we can separate memo author from table `memo_logs`. 

- [x] Add table `memo_authors` to represent many2many relationship between `community_members` and `memo_logs`. In this way, a `memo_logs` can have multiple authors. And author now can be everyone in the community, not be restricted by employees like in the past. 
- [x]  Update controller method  `memolog.Sync` to sync memos and their authors with the new model
- [x] Remove whitelisted user, now we need to query `community_members` to check if user exists 
- [x] Remove column `authors` in the table `memo_logs`
Reproduce/Testing

![image](https://github.com/dwarvesf/fortress-api/assets/32956772/77a1943b-a949-4d4b-b0d5-c2ecfef6782b)
![image](https://github.com/dwarvesf/fortress-api/assets/32956772/8b24faf5-d277-4221-a69f-28ccf81c809d)
