### PR TITLE
fix: separate memo authors by referencing to discord accounts

### DIFF
--- a/migrations/schemas/20240513093025-extend_table_discount_accounts.sql
+++ b/migrations/schemas/20240513093025-extend_table_discount_accounts.sql
@@ -1,0 +1,27 @@
+-- +migrate Up
+ALTER TABLE discord_accounts
+RENAME COLUMN username TO discord_username;
+
+ALTER TABLE discord_accounts  
+ALTER COLUMN discord_username SET NOT NULL,
+ALTER COLUMN discord_username SET DEFAULT '';
+
+ALTER TABLE discord_accounts
+ADD COLUMN roles TEXT[] DEFAULT NULL,
+ADD COLUMN memo_username TEXT NOT NULL DEFAULT '',
+ADD COLUMN github_username TEXT NOT NULL DEFAULT '',
+ADD COLUMN personal_email TEXT NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE discord_accounts
+DROP COLUMN roles,
+DROP COLUMN memo_username,
+DROP COLUMN github_username,
+DROP COLUMN personal_email;
+
+ALTER TABLE discord_accounts
+ALTER COLUMN discord_username DROP DEFAULT,
+ALTER COLUMN discord_username DROP NOT NULL;
+
+ALTER TABLE discord_accounts
+RENAME COLUMN discord_username TO username;

--- a/migrations/schemas/20240513105259-add_table_memo_authors_and_unique_memo_link.sql
+++ b/migrations/schemas/20240513105259-add_table_memo_authors_and_unique_memo_link.sql
@@ -1,0 +1,14 @@
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS memo_authors  (
+  memo_log_id UUID NOT NULL REFERENCES memo_logs(id),
+  discord_account_id UUID NOT NULL REFERENCES discord_accounts(id),
+  created_at    TIMESTAMP(6)     DEFAULT (now()),
+  PRIMARY KEY (memo_log_id, discord_account_id)
+);
+
+ALTER TABLE memo_logs ADD UNIQUE ("url");
+-- +migrate Down
+ALTER TABLE memo_logs DROP CONSTRAINT memo_logs_url_key;
+
+DROP TABLE IF EXISTS memo_authors;

--- a/migrations/schemas/20240513164949-remove_column_memo_logs_authors.sql
+++ b/migrations/schemas/20240513164949-remove_column_memo_logs_authors.sql
@@ -1,0 +1,5 @@
+
+-- +migrate Up
+ALTER TABLE memo_logs DROP COLUMN IF EXISTS authors;
+-- +migrate Down
+ALTER TABLE memo_logs ADD COLUMN authors JSONB;

--- a/migrations/seed/social_accounts.sql
+++ b/migrations/seed/social_accounts.sql
@@ -130,7 +130,7 @@ INSERT INTO public.social_accounts (id, deleted_at, created_at, updated_at, empl
 ('df704e6d-23c8-4e81-bcf3-aa7793eb767c', NULL, '2023-02-01 23:35:58.650083', '2023-02-01 23:35:58.650083', 'bc075c77-788f-4577-a322-f4db31249530', 'linkedin', 'Hoang Nguyen', NULL, 'Hoang Nguyen'),
 ('25a22d62-afa6-4629-aa2f-1f41e6045d76', NULL, '2023-02-01 23:35:58.650083', '2023-02-01 23:35:58.650083', '347745af-3523-43e2-bb08-1ad5a433cc9e', 'linkedin', 'Nam Nguyen', NULL, 'Nam Nguyen');
 
-INSERT INTO discord_accounts (id, deleted_at, created_at, updated_at, discord_id, username)
+INSERT INTO discord_accounts (id, deleted_at, created_at, updated_at, discord_id, discord_username)
 SELECT id, deleted_at, created_at, updated_at, account_id, name
 FROM social_accounts
 WHERE type = 'discord';

--- a/pkg/controller/deliverymetrics/leaderboard.go
+++ b/pkg/controller/deliverymetrics/leaderboard.go
@@ -40,7 +40,7 @@ func (c controller) GetWeeklyLeaderBoard() (*model.LeaderBoard, error) {
 			EmployeeName:    e.DisplayName,
 			Points:          m.SumWeight,
 			DiscordID:       d.DiscordID,
-			DiscordUsername: d.Username,
+			DiscordUsername: d.DiscordUsername,
 		}
 		if m.SumEffort.IsZero() {
 			item.Effectiveness = decimal.NewFromFloat(0)
@@ -96,7 +96,7 @@ func (c controller) GetMonthlyLeaderBoard(month *time.Time) (*model.LeaderBoard,
 			}
 			if d != nil {
 				item.DiscordID = d.DiscordID
-				item.DiscordUsername = d.Username
+				item.DiscordUsername = d.DiscordUsername
 			}
 		}
 

--- a/pkg/controller/employee/update_general_info.go
+++ b/pkg/controller/employee/update_general_info.go
@@ -187,8 +187,8 @@ func (r *controller) UpdateGeneralInfo(employeeID string, body UpdateEmployeeGen
 	}
 
 	discordAccountInput := &model.DiscordAccount{
-		DiscordID: discordID,
-		Username:  body.DiscordName,
+		DiscordID:       discordID,
+		DiscordUsername: body.DiscordName,
 	}
 
 	discordAccount, err := r.store.DiscordAccount.Upsert(tx.DB(), discordAccountInput)

--- a/pkg/controller/memologs/sync.go
+++ b/pkg/controller/memologs/sync.go
@@ -2,10 +2,8 @@ package memologs
 
 import (
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -13,8 +11,34 @@ import (
 	"github.com/dwarvesf/fortress-api/pkg/logger"
 	"github.com/dwarvesf/fortress-api/pkg/model"
 	"github.com/dwarvesf/fortress-api/pkg/utils/timeutil"
-	"github.com/shopspring/decimal"
 )
+
+const (
+	dfMemoRssURL = "https://memo.d.foundation/index.xml"
+)
+
+// retrieveLatestMemoFeed call to memo.d.foundation to get the rss feed
+func retrieveLatestMemoFeed(l logger.Logger) (Rss, error) {
+	resp, err := http.Get(dfMemoRssURL)
+	if err != nil {
+		l.Errorf(err, "failed to get rss feed from %s, status code: %d", dfMemoRssURL, resp.StatusCode)
+		return Rss{}, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		l.Error(err, "failed to read rss feed from response body")
+		return Rss{}, err
+	}
+
+	d := Rss{}
+	if err := xml.Unmarshal(data, &d); err != nil {
+		l.Errorf(err, "failed to unmarshal rss feed with content: %s", string(data))
+	}
+
+	return d, nil
+}
 
 func (c *controller) Sync() ([]model.MemoLog, error) {
 	l := c.logger.Fields(logger.Fields{
@@ -22,145 +46,92 @@ func (c *controller) Sync() ([]model.MemoLog, error) {
 		"method":     "Sync",
 	})
 
-	list, err := c.store.MemoLog.List(c.repo.DB())
+	// TODO: need optimize this, for example just only get synced memos today
+	syncedMemos, err := c.store.MemoLog.List(c.repo.DB())
 	if err != nil {
-		l.Error(err, "failed to get memo logs")
+		l.Errorf(err, "failed to get synced memos")
 		return nil, err
 	}
 
-	mapMemo := make(map[string]bool)
-	for _, memo := range list {
-		mapMemo[memo.URL] = true
+	mapSyncedMemos := make(map[string]model.MemoLog)
+	for _, memo := range syncedMemos {
+		mapSyncedMemos[memo.URL] = memo
 	}
 
-	url := "https://memo.d.foundation/index.xml"
-	response, err := http.Get(url)
+	latestMemoFeed, err := retrieveLatestMemoFeed(l)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
-	defer response.Body.Close()
+	newMemos := make([]model.MemoLog, 0)
+	for _, item := range latestMemoFeed.Channel.Item {
+		l.Infof("Syncing memo: %s", item.Link)
 
-	data, err := io.ReadAll(response.Body)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	d := Rss{}
-	err = xml.Unmarshal(data, &d)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	authorsMap := make(map[string]model.MemoLogAuthor)
-	memoLogs := make([]model.MemoLog, 0)
-	for _, item := range d.Channel.Item {
-		if mapMemo[item.Link] {
+		// Ignore if memo is already synced
+		if _, ok := mapSyncedMemos[item.Link]; ok {
+			l.Infof("Memo is already synced: %s", item.Link)
 			continue
 		}
 
-		authorStrList := strings.Split(item.Author, ",")
-		memoAuthors := make([]model.MemoLogAuthor, 0)
-		for _, author := range authorStrList {
-			author = strings.TrimSpace(author)
-			if author == "" {
-				continue
-			}
-
-			discordID, found := whitelistedUsers[author]
-			if !found {
-				continue
-			}
-
-			dt, found := authorsMap[discordID]
-			if found {
-				memoAuthors = append(memoAuthors, dt)
-				continue
-			}
-
-			empl, err := c.store.Employee.GetByDiscordID(c.repo.DB(), discordID, true)
-			if err != nil {
-				l.Error(err, fmt.Sprintf("failed to get employee with discord username %v", discordID))
-			}
-
-			github := ""
-			discord := discordID
-			employeeID := ""
-			if empl != nil {
-				employeeID = empl.ID.String()
-				githubSA := model.SocialAccounts(empl.SocialAccounts).GetGithub()
-				if githubSA != nil {
-					github = githubSA.AccountID
-				}
-
-				if empl.DiscordAccount != nil {
-					discord = empl.DiscordAccount.DiscordID
-				}
-			}
-
-			if github != "" || discord != "" || employeeID != "" {
-				memoAuthor := model.MemoLogAuthor{
-					GithubID:   github,
-					DiscordID:  discord,
-					EmployeeID: employeeID,
-				}
-				authorsMap[discordID] = memoAuthor
-				memoAuthors = append(memoAuthors, memoAuthor)
-			}
-		}
-
-		layout := "Mon, 02 Jan 2006 15:04:05 -0700"
-		publishedAt, err := time.Parse(layout, item.PubDate)
+		// Ignore if memo is not published today
+		publishedAt, err := time.Parse(time.RFC1123Z, item.PubDate)
 		if err != nil {
 			l.Error(err, fmt.Sprintf("failed to parse date %v", item.PubDate))
+			continue
 		}
-
 		if !timeutil.IsSameDay(publishedAt, time.Now()) {
 			continue
 		}
 
-		memoLogs = append(memoLogs, model.MemoLog{
+		// Ignore if memo have no author
+		if strings.TrimSpace(item.Author) == "" {
+			continue
+		}
+
+		// This should be author discord username
+		authorUsernames := strings.Split(strings.TrimSpace(item.Author), ",")
+		if len(authorUsernames) == 0 {
+			continue
+		}
+
+		// Get author by memo usernames, ignore any author if not found
+		// Expect that we do not have huge number of memo each day, so do not need to fear this loop spam get authors
+		authors, err := c.store.DiscordAccount.ListByMemoUsername(c.repo.DB(), authorUsernames)
+		if err != nil {
+			l.Errorf(err, "failed to get authors by discord usernames: %v", authorUsernames)
+			continue
+		}
+
+		// Temporary ignore if no author found, do not need to enrich community member info here, it make this function too complex. This task should be done by another cron job
+		if len(authors) == 0 {
+			continue
+		}
+
+		// Create memo log
+		memo := model.MemoLog{
 			Title:       item.Title,
 			URL:         item.Link,
-			Authors:     memoAuthors,
 			Description: item.Description,
 			PublishedAt: &publishedAt,
-			Reward:      decimal.Decimal{},
-		})
+			Authors:     authors,
+		}
+
+		newMemos = append(newMemos, memo)
 	}
 
-	if len(memoLogs) == 0 {
+	if len(newMemos) == 0 {
+		l.Info("No new memo is published today")
 		return nil, nil
 	}
 
-	results, err := c.store.MemoLog.Create(c.repo.DB(), memoLogs)
+	// Create new memos
+	results, err := c.store.MemoLog.Create(c.repo.DB(), newMemos)
 	if err != nil {
-		return nil, errors.New("failed to create new memo")
+		l.Errorf(err, "failed to create new memos")
+		return nil, err
 	}
 
 	return results, nil
-}
-
-var whitelistedUsers = map[string]string{
-	"thanh":        "790170208228212766",
-	"giangthan":    "797051426437595136",
-	"nikki":        "796991130184187944",
-	"anna":         "575525326181105674",
-	"monotykamary": "184354519726030850",
-	"vhbien":       "421992793582469130",
-	"minhcloud":    "1007496699511570503",
-	"mickwan1234":  "383793994271948803",
-	"hnh":          "567326528216760320",
-	"duy":          "788351441097195520",
-	"huytq":        "361172853326086144",
-	"han":          "151497832853929986",
-	"namtran":      "785756392363524106",
-	"innno_":       "753995829559165044",
-	"dudaka":       "282500790692741121",
-	"tom":          "184354519726030850",
-	"minh":         "1093434004159594496",
-	"jack":         "398384659521863702",
 }
 
 type Rss struct {

--- a/pkg/handler/discord/discord.go
+++ b/pkg/handler/discord/discord.go
@@ -79,15 +79,15 @@ func (h *handler) SyncDiscordInfo(c *gin.Context) {
 	tx, done := h.repo.NewTransaction()
 
 	for _, da := range discordAccounts {
-		if da.DiscordID == "" && da.Username == "" {
+		if da.DiscordID == "" && da.DiscordUsername == "" {
 			continue
 		}
 
 		// Update discord_id from username
 		if da.DiscordID == "" {
-			discordID, ok := discordUsernameMap[da.Username]
+			discordID, ok := discordUsernameMap[da.DiscordUsername]
 			if !ok {
-				h.logger.AddField("username", da.Username).Info("username does not exist in guild")
+				h.logger.AddField("username", da.DiscordUsername).Info("username does not exist in guild")
 				continue
 			}
 
@@ -107,9 +107,9 @@ func (h *handler) SyncDiscordInfo(c *gin.Context) {
 			continue
 		}
 
-		if da.Username != username {
-			da.Username = username
-			_, err := h.store.DiscordAccount.UpdateSelectedFieldsByID(tx.DB(), da.ID.String(), *da, "username")
+		if da.DiscordUsername != username {
+			da.DiscordUsername = username
+			_, err := h.store.DiscordAccount.UpdateSelectedFieldsByID(tx.DB(), da.ID.String(), *da, "discord_username")
 			if err != nil {
 				h.logger.AddField("id", da.ID).Error(err, "failed to update username of discord account")
 			}

--- a/pkg/handler/profile/profile.go
+++ b/pkg/handler/profile/profile.go
@@ -201,8 +201,8 @@ func (h *handler) UpdateInfo(c *gin.Context) {
 	}
 
 	discordAccountInput := &model.DiscordAccount{
-		DiscordID: discordID,
-		Username:  input.DiscordName,
+		DiscordID:       discordID,
+		DiscordUsername: input.DiscordName,
 	}
 
 	discordAccount, err := h.store.DiscordAccount.Upsert(tx.DB(), discordAccountInput)
@@ -795,8 +795,8 @@ func (h *handler) SubmitOnboardingForm(c *gin.Context) {
 	}
 
 	discordAccountInput := &model.DiscordAccount{
-		DiscordID: discordID,
-		Username:  input.DiscordName,
+		DiscordID:       discordID,
+		DiscordUsername: input.DiscordName,
 	}
 
 	discordAccount, err := h.store.DiscordAccount.Upsert(tx.DB(), discordAccountInput)

--- a/pkg/model/discord_account.go
+++ b/pkg/model/discord_account.go
@@ -1,8 +1,16 @@
 package model
 
+import "github.com/lib/pq"
+
 type DiscordAccount struct {
 	BaseModel
 
-	DiscordID string
-	Username  string
+	DiscordID       string
+	DiscordUsername string         `json:"discord_username"`
+	MemoUsername    string         `json:"memo_username"`
+	Roles           pq.StringArray `json:"role" gorm:"type:text[]"`
+	GithubUsername  string         `json:"github_username"`
+	PersonalEmail   string         `json:"personal_email"`
+
+	Employee *Employee `json:"employee"`
 }

--- a/pkg/model/memo_author.go
+++ b/pkg/model/memo_author.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// MemoAuthor is the join table for memo log and discord account
+type MemoAuthor struct {
+	MemoLogID        UUID `gorm:"primaryKey"`
+	DiscordAccountID UUID `gorm:"primaryKey"`
+	CreatedAt        time.Time
+}
+
+func (b *MemoAuthor) BeforeCreate(tx *gorm.DB) (err error) {
+	cols := []clause.Column{}
+	for _, field := range tx.Statement.Schema.PrimaryFields {
+		cols = append(cols, clause.Column{Name: field.DBName})
+	}
+	tx.Statement.AddClause(clause.OnConflict{
+		Columns:   cols,
+		DoNothing: true,
+	})
+
+	return nil
+}

--- a/pkg/model/memo_log.go
+++ b/pkg/model/memo_log.go
@@ -1,12 +1,10 @@
 package model
 
 import (
-	"database/sql/driver"
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
 )
 
 type MemoLog struct {
@@ -14,39 +12,14 @@ type MemoLog struct {
 
 	Title       string
 	URL         string
-	Authors     MemoLogAuthors
 	Tags        JSONArrayString
 	Description string
 	PublishedAt *time.Time
 	Reward      decimal.Decimal
+
+	Authors []DiscordAccount `json:"authors" gorm:"many2many:memo_authors;"`
 }
 
-type MemoLogAuthors []MemoLogAuthor
-
-// MemoLogAuthor is the author of the memo log
-type MemoLogAuthor struct {
-	EmployeeID string `json:"employeeID"`
-	GithubID   string `json:"githubID"`
-	DiscordID  string `json:"discordID"`
-}
-
-func (j MemoLogAuthors) Value() (driver.Value, error) {
-	return json.Marshal(j)
-}
-
-func (j *MemoLogAuthors) Scan(value interface{}) error {
-	if value == nil {
-		*j = nil
-		return nil
-	}
-	switch t := value.(type) {
-	case []uint8:
-		jsonData := value.([]uint8)
-		if string(jsonData) == "null" {
-			return nil
-		}
-		return json.Unmarshal(jsonData, j)
-	default:
-		return fmt.Errorf("could not scan type %T into json", t)
-	}
+func (MemoLog) BeforeCreate(db *gorm.DB) error {
+	return db.SetupJoinTable(&MemoLog{}, "Authors", &MemoAuthor{})
 }

--- a/pkg/service/github/github.go
+++ b/pkg/service/github/github.go
@@ -109,3 +109,13 @@ func (s githubService) RemoveFromOrganizationByUsername(ctx context.Context, use
 
 	return nil
 }
+
+func (s githubService) RetrieveUsernameByID(ctx context.Context, id int64) (string, error) {
+	user, _, err := s.Client.Users.GetByID(ctx, id)
+	if err != nil {
+		s.log.Errorf(err, "[RetrieveUsernameByID] fail to get user by id", "id", id)
+		return "", err
+	}
+
+	return user.GetLogin(), nil
+}

--- a/pkg/service/github/service.go
+++ b/pkg/service/github/service.go
@@ -10,4 +10,5 @@ type IService interface {
 	RemoveFromOrganizationByEmail(ctx context.Context, email string) error
 	RemoveFromOrganizationByUsername(ctx context.Context, username string) error
 	SendInvitationByEmail(ctx context.Context, e *model.Employee) error
+	RetrieveUsernameByID(ctx context.Context, id int64) (string, error)
 }

--- a/pkg/service/mochiprofile/request.go
+++ b/pkg/service/mochiprofile/request.go
@@ -6,6 +6,7 @@ type ProfilePlatform string
 
 const (
 	ProfilePlatformDiscord ProfilePlatform = "discord"
+	ProfilePlatformGithub  ProfilePlatform = "github"
 )
 
 type Pagination struct {

--- a/pkg/store/discordaccount/discord_account.go
+++ b/pkg/store/discordaccount/discord_account.go
@@ -24,7 +24,7 @@ func (r *store) Upsert(db *gorm.DB, da *model.DiscordAccount) (*model.DiscordAcc
 				},
 				DoUpdates: clause.Assignments(
 					map[string]interface{}{
-						"username": da.Username,
+						"discord_username": da.DiscordUsername,
 					},
 				),
 			},
@@ -51,4 +51,19 @@ func (r *store) OneByDiscordID(db *gorm.DB, discordID string) (*model.DiscordAcc
 func (r *store) UpdateSelectedFieldsByID(db *gorm.DB, id string, updateModel model.DiscordAccount, updatedFields ...string) (a *model.DiscordAccount, err error) {
 	discordAccount := model.DiscordAccount{}
 	return &discordAccount, db.Model(&discordAccount).Where("id = ?", id).Select(updatedFields).Updates(updateModel).Error
+}
+
+// ListByMemoUsername gets a list of discord accounts by memo usernames
+func (r *store) ListByMemoUsername(db *gorm.DB, usernames []string) ([]model.DiscordAccount, error) {
+	var cms []model.DiscordAccount
+	err := db.Where("memo_username IN (?)", usernames).Find(&cms).Error
+	return cms, err
+}
+
+// Insert inserts a new discord account
+func (r *store) Insert(db *gorm.DB, cm *model.DiscordAccount) error {
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "discord_id"}, {Name: "discord_username"}},
+		DoNothing: true,
+	}).Create(cm).Error
 }

--- a/pkg/store/discordaccount/interface.go
+++ b/pkg/store/discordaccount/interface.go
@@ -13,4 +13,9 @@ type IStore interface {
 
 	Upsert(db *gorm.DB, da *model.DiscordAccount) (*model.DiscordAccount, error)
 	UpdateSelectedFieldsByID(db *gorm.DB, id string, client model.DiscordAccount, updatedFields ...string) (a *model.DiscordAccount, err error)
+
+	// ListByMemoUsername gets a list of discord accounts by memo usernames
+	ListByMemoUsername(db *gorm.DB, usernames []string) ([]model.DiscordAccount, error)
+	// Insert inserts a discord account
+	Insert(db *gorm.DB, cm *model.DiscordAccount) error
 }

--- a/pkg/store/memolog/memo_log.go
+++ b/pkg/store/memolog/memo_log.go
@@ -16,7 +16,7 @@ func New() IStore {
 
 // Create creates a memo log record in the database
 func (s *store) Create(db *gorm.DB, b []model.MemoLog) ([]model.MemoLog, error) {
-	return b, db.Create(b).Error
+	return b, db.Table("memo_logs").Create(b).Error
 }
 
 // GetLimitByTimeRange gets memo logs in a specific time range, with limit
@@ -28,5 +28,5 @@ func (s *store) GetLimitByTimeRange(db *gorm.DB, start, end *time.Time, limit in
 // List gets all memo logs
 func (s *store) List(db *gorm.DB) ([]model.MemoLog, error) {
 	var logs []model.MemoLog
-	return logs, db.Order("published_at DESC").Find(&logs).Error
+	return logs, db.Preload("Authors").Preload("Authors.Employee").Order("published_at DESC").Find(&logs).Error
 }

--- a/pkg/view/employee.go
+++ b/pkg/view/employee.go
@@ -324,7 +324,7 @@ func ToUpdateGeneralInfoEmployeeData(employee *model.Employee) *UpdateGeneralInf
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	if employee.LineManager != nil {
@@ -412,7 +412,7 @@ func ToOneEmployeeData(employee *model.Employee, userInfo *model.CurrentLoggedUs
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	if userInfo != nil && authutils.HasPermission(userInfo.Permissions, model.PermissionEmployeesBaseSalaryRead) {
@@ -524,7 +524,7 @@ func ToEmployeeData(employee *model.Employee) *EmployeeData {
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	if len(employee.Mentees) > 0 {
@@ -828,7 +828,7 @@ func ToDiscordEmployeeDetail(employee *model.Employee, userInfo *model.CurrentLo
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	rs.NotionID = empSocialData.NotionID

--- a/pkg/view/memo.go
+++ b/pkg/view/memo.go
@@ -19,9 +19,12 @@ type MemoLog struct {
 
 // MemoLogAuthor is the author of the memo log
 type MemoLogAuthor struct {
-	EmployeeID string `json:"employeeID"`
-	GithubID   string `json:"githubID"`
-	DiscordID  string `json:"discordID"`
+	EmployeeID      string `json:"employeeID"`
+	GithubUsername  string `json:"githubUsername"`
+	DiscordID       string `json:"discordID"`
+	DiscordUsername string `json:"discordUsername"`
+	PersonalEmail   string `json:"personalEmail"`
+	MemoUsername    string `json:"memoUsername"`
 }
 
 // MemoLogsResponse response for memo logs
@@ -34,10 +37,18 @@ func ToMemoLog(memoLogs []model.MemoLog) []MemoLog {
 	for _, memoLog := range memoLogs {
 		authors := make([]MemoLogAuthor, 0)
 		for _, author := range memoLog.Authors {
+			var employeeID string
+			if author.Employee != nil {
+				employeeID = author.Employee.ID.String()
+			}
+
 			authors = append(authors, MemoLogAuthor{
-				EmployeeID: author.EmployeeID,
-				GithubID:   author.GithubID,
-				DiscordID:  author.DiscordID,
+				EmployeeID:      employeeID,
+				GithubUsername:  author.GithubUsername,
+				DiscordID:       author.DiscordID,
+				PersonalEmail:   author.PersonalEmail,
+				DiscordUsername: author.DiscordUsername,
+				MemoUsername:    author.MemoUsername,
 			})
 		}
 

--- a/pkg/view/profile.go
+++ b/pkg/view/profile.go
@@ -106,7 +106,7 @@ func ToUpdateProfileInfoData(employee *model.Employee) *UpdateProfileInfoData {
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	return rs
@@ -156,7 +156,7 @@ func ToProfileData(employee *model.Employee) *ProfileData {
 
 	if employee.DiscordAccount != nil {
 		rs.DiscordID = employee.DiscordAccount.DiscordID
-		rs.DiscordName = employee.DiscordAccount.Username
+		rs.DiscordName = employee.DiscordAccount.DiscordUsername
 	}
 
 	return rs

--- a/pkg/view/salary.go
+++ b/pkg/view/salary.go
@@ -63,7 +63,7 @@ func ToSalaryAdvanceReport(result model.SalaryAdvanceReport) *SalaryAdvanceRepor
 		salaryAdvances = append(salaryAdvances, AggregatedSalaryAdvance{
 			EmployeeID:      v.EmployeeID,
 			DiscordID:       v.Employee.DiscordAccount.DiscordID,
-			DiscordUsername: v.Employee.DiscordAccount.Username,
+			DiscordUsername: v.Employee.DiscordAccount.DiscordUsername,
 			AmountICY:       v.AmountICY,
 			AmountUSD:       v.AmountUSD,
 		})


### PR DESCRIPTION
#### What's this PR do?

This API contains all changes from #697 , #698 and #700. But instead of add new `community_members`, this PR extend table `discord_account` instead.

![image](https://github.com/dwarvesf/fortress-api/assets/32956772/69af365c-ea46-415b-8eee-f6fce9b9c621)
![image](https://github.com/dwarvesf/fortress-api/assets/32956772/a4c93abb-023b-4c0a-8bdf-5b2f2fedc07c)
