### PR TITLE
fix: use discord username as optional in querying discord accounts

### DIFF
--- a/pkg/store/discordaccount/discord_account.go
+++ b/pkg/store/discordaccount/discord_account.go
@@ -56,9 +56,9 @@ func (r *store) UpdateSelectedFieldsByID(db *gorm.DB, id string, updateModel mod
 	return &discordAccount, db.Model(&discordAccount).Where("id = ?", id).Select(updatedFields).Updates(updateModel).Error
 }
 
-// ListByMemoUsername gets a list of discord accounts by memo usernames
+// ListByMemoUsername gets a list of discord accounts by memo usernames, if memo username is not found, it will try to find by discord username
 func (r *store) ListByMemoUsername(db *gorm.DB, usernames []string) ([]model.DiscordAccount, error) {
 	var cms []model.DiscordAccount
-	err := db.Where("memo_username IN (?)", usernames).Find(&cms).Error
+	err := db.Where("memo_username IN (?) OR discord_username IN (?)", usernames, usernames).Find(&cms).Error
 	return cms, err
 }


### PR DESCRIPTION
#### What's this PR do?

Use discord username as memo username when query list discord account by memo username