### PR TITLE
fix: sync memo with non-discord authors

### DIFF
--- a/pkg/controller/memologs/sync.go
+++ b/pkg/controller/memologs/sync.go
@@ -2,44 +2,19 @@ package memologs
 
 import (
 	"encoding/xml"
-	"fmt"
-	"io"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/dwarvesf/fortress-api/pkg/logger"
 	"github.com/dwarvesf/fortress-api/pkg/model"
-	"github.com/dwarvesf/fortress-api/pkg/store/memolog"
-	"github.com/dwarvesf/fortress-api/pkg/utils/timeutil"
+	"gorm.io/gorm"
 )
 
 const (
 	dfMemoRssURL = "https://memo.d.foundation/index.xml"
 )
-
-// retrieveLatestMemoFeed call to memo.d.foundation to get the rss feed
-func retrieveLatestMemoFeed(l logger.Logger) (Rss, error) {
-	resp, err := http.Get(dfMemoRssURL)
-	if err != nil {
-		l.Errorf(err, "failed to get rss feed from %s, status code: %d", dfMemoRssURL, resp.StatusCode)
-		return Rss{}, err
-	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		l.Error(err, "failed to read rss feed from response body")
-		return Rss{}, err
-	}
-
-	d := Rss{}
-	if err := xml.Unmarshal(data, &d); err != nil {
-		l.Errorf(err, "failed to unmarshal rss feed with content: %s", string(data))
-	}
-
-	return d, nil
-}
 
 func (c *controller) Sync() ([]model.MemoLog, error) {
 	l := c.logger.Fields(logger.Fields{
@@ -47,82 +22,90 @@ func (c *controller) Sync() ([]model.MemoLog, error) {
 		"method":     "Sync",
 	})
 
-	// TODO: need optimize this, for example just only get synced memos today
-	syncedMemos, err := c.store.MemoLog.List(c.repo.DB(), memolog.ListFilter{})
-	if err != nil {
-		l.Errorf(err, "failed to get synced memos")
+	latestMemo, err := c.store.MemoLog.Latest(c.repo.DB())
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		l.Errorf(err, "failed to get latest memo")
 		return nil, err
 	}
 
-	mapSyncedMemos := make(map[string]model.MemoLog)
-	for _, memo := range syncedMemos {
-		mapSyncedMemos[memo.URL] = memo
-	}
-
-	latestMemoFeed, err := retrieveLatestMemoFeed(l)
+	resp, err := http.Get(dfMemoRssURL)
 	if err != nil {
+		l.Errorf(err, "failed to get rss feed from %s, status code: %d", dfMemoRssURL, resp.StatusCode)
 		return nil, err
 	}
+	defer resp.Body.Close()
 
+	decoder := xml.NewDecoder(resp.Body)
+
+	inItem := false
+	currentElem := ""
+	item := Item{}
 	newMemos := make([]model.MemoLog, 0)
-	for _, item := range latestMemoFeed.Channel.Item {
-		l.Infof("Syncing memo: %s", item.Link)
-
-		// Ignore if memo is already synced
-		if _, ok := mapSyncedMemos[item.Link]; ok {
-			l.Infof("Memo is already synced: %s", item.Link)
-			continue
-		}
-
-		// Ignore if memo is not published today
-		publishedAt, err := time.Parse(time.RFC1123Z, item.PubDate)
+	for latestMemo.Title != item.Title || item.Title == "" {
+		token, err := decoder.Token()
 		if err != nil {
-			l.Error(err, fmt.Sprintf("failed to parse date %v", item.PubDate))
-			continue
-		}
-		if !timeutil.IsSameDay(publishedAt, time.Now()) {
-			continue
+			break
 		}
 
-		// Ignore if memo have no author
-		if strings.TrimSpace(item.Author) == "" {
-			continue
+		switch se := token.(type) {
+		case xml.StartElement:
+			currentElem = se.Name.Local
+			if se.Name.Local == "item" {
+				inItem = true
+				item = Item{}
+			}
+		case xml.EndElement:
+			if se.Name.Local == "item" {
+				inItem = false
+
+				if latestMemo.Title == item.Title {
+					break
+				}
+
+				pubDate, _ := time.Parse(time.RFC1123Z, item.PubDate)
+				authorUsernames := make([]string, 0)
+				for _, s := range strings.Split(strings.TrimSpace(item.Author), ",") {
+					if s != "" {
+						authorUsernames = append(authorUsernames, strings.TrimSpace(s))
+					}
+				}
+
+				authors, err := c.store.DiscordAccount.ListByMemoUsername(c.repo.DB(), authorUsernames)
+				if err != nil {
+					l.Errorf(err, "failed to get authors by discord usernames: %v", authorUsernames)
+					continue
+				}
+
+				newMemos = append(newMemos, model.MemoLog{
+					Title:               item.Title,
+					URL:                 item.Link,
+					Description:         item.Description,
+					PublishedAt:         &pubDate,
+					Authors:             authors,
+					AuthorMemoUsernames: authorUsernames,
+				})
+			}
+		case xml.CharData:
+			if inItem {
+				data := string(se)
+				switch currentElem {
+				case "title":
+					item.Title = data
+				case "link":
+					item.Link = data
+				case "pubDate":
+					item.PubDate = data
+				case "author":
+					item.Author = data
+				case "guid":
+					item.Guid = data
+				case "description":
+					item.Description = data
+				case "draft":
+					item.Draft = data
+				}
+			}
 		}
-
-		// This should be author discord username
-		authorUsernames := strings.Split(strings.TrimSpace(item.Author), ",")
-		if len(authorUsernames) == 0 {
-			continue
-		}
-
-		// Get author by memo usernames, ignore any author if not found
-		// Expect that we do not have huge number of memo each day, so do not need to fear this loop spam get authors
-		authors, err := c.store.DiscordAccount.ListByMemoUsername(c.repo.DB(), authorUsernames)
-		if err != nil {
-			l.Errorf(err, "failed to get authors by discord usernames: %v", authorUsernames)
-			continue
-		}
-
-		// Temporary ignore if no author found, do not need to enrich community member info here, it make this function too complex. This task should be done by another cron job
-		if len(authors) == 0 {
-			continue
-		}
-
-		// Create memo log
-		memo := model.MemoLog{
-			Title:       item.Title,
-			URL:         item.Link,
-			Description: item.Description,
-			PublishedAt: &publishedAt,
-			Authors:     authors,
-		}
-
-		newMemos = append(newMemos, memo)
-	}
-
-	if len(newMemos) == 0 {
-		l.Info("No new memo is published today")
-		return nil, nil
 	}
 
 	// Create new memos
@@ -135,37 +118,12 @@ func (c *controller) Sync() ([]model.MemoLog, error) {
 	return results, nil
 }
 
-type Rss struct {
-	XMLName xml.Name `xml:"rss"`
-	Text    string   `xml:",chardata"`
-	Atom    string   `xml:"atom,attr"`
-	Version string   `xml:"version,attr"`
-	Script  string   `xml:"script"`
-	Channel struct {
-		Text  string `xml:",chardata"`
-		Title string `xml:"title"`
-		Link  struct {
-			Text string `xml:",chardata"`
-			Href string `xml:"href,attr"`
-			Rel  string `xml:"rel,attr"`
-			Type string `xml:"type,attr"`
-		} `xml:"link"`
-		Description    string `xml:"description"`
-		Generator      string `xml:"generator"`
-		Language       string `xml:"language"`
-		ManagingEditor string `xml:"managingEditor"`
-		WebMaster      string `xml:"webMaster"`
-		Copyright      string `xml:"copyright"`
-		LastBuildDate  string `xml:"lastBuildDate"`
-		Item           []struct {
-			Text        string `xml:",chardata"`
-			Title       string `xml:"title"`
-			Link        string `xml:"link"`
-			PubDate     string `xml:"pubDate"`
-			Author      string `xml:"author"`
-			Guid        string `xml:"guid"`
-			Description string `xml:"description"`
-			Draft       string `xml:"draft"`
-		} `xml:"item"`
-	} `xml:"channel"`
+type Item struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	PubDate     string `xml:"pubDate"`
+	Author      string `xml:"author"`
+	Guid        string `xml:"guid"`
+	Description string `xml:"description"`
+	Draft       string `xml:"draft"`
 }

--- a/pkg/model/memo_log.go
+++ b/pkg/model/memo_log.go
@@ -18,6 +18,9 @@ type MemoLog struct {
 	Reward      decimal.Decimal
 
 	Authors []DiscordAccount `json:"authors" gorm:"many2many:memo_authors;"`
+
+	// This field is used to make sure response always contains authors
+	AuthorMemoUsernames []string `json:"-" gorm:"-"`
 }
 
 func (MemoLog) BeforeCreate(db *gorm.DB) error {

--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -665,21 +665,21 @@ func (d *discordClient) SendNewMemoMessage(guildID string, memos []model.MemoLog
 			var textMessage string
 
 			authorField := ""
-			avatar := ""
 			for _, author := range content.Authors {
-				if avatar == "" {
-					discordMember, err := d.session.GuildMember(guildID, content.Authors[0].DiscordID)
-					if err != nil {
-						return nil, err
-					}
-
-					avatar = fmt.Sprintf("https://cdn.discordapp.com/avatars/%v/%v.webp?size=240", discordMember.User.ID, discordMember.User.Avatar)
-					if discordMember.Avatar != "" {
-						avatar = fmt.Sprintf("https://cdn.discordapp.com/guilds/%v/users/%v/avatars/%v.webp?size=240", guildID, discordMember.User.ID, discordMember.Avatar)
-					}
+				if author.DiscordID != "" {
+					authorField += fmt.Sprintf(" <@%s> ", author.DiscordID)
+				} else if author.DiscordUsername != "" {
+					authorField += fmt.Sprintf(" @%s ", author.DiscordUsername)
+				} else {
+					authorField += " **@unknown-user**"
 				}
+			}
 
-				authorField += fmt.Sprintf(" <@%s> ", author.DiscordID)
+			// Use memo username if discord username is not available
+			if authorField == "" {
+				for _, author := range content.AuthorMemoUsernames {
+					authorField += fmt.Sprintf(" **%s** ", author)
+				}
 			}
 
 			author := ""

--- a/pkg/store/memolog/interface.go
+++ b/pkg/store/memolog/interface.go
@@ -12,4 +12,5 @@ type IStore interface {
 	Create(db *gorm.DB, b []model.MemoLog) ([]model.MemoLog, error)
 	GetLimitByTimeRange(db *gorm.DB, start, end *time.Time, limit int) ([]model.MemoLog, error)
 	List(db *gorm.DB, filter ListFilter) ([]model.MemoLog, error)
+	Latest(db *gorm.DB) (model.MemoLog, error)
 }

--- a/pkg/store/memolog/memo_log.go
+++ b/pkg/store/memolog/memo_log.go
@@ -44,3 +44,9 @@ func (s *store) List(db *gorm.DB, filter ListFilter) ([]model.MemoLog, error) {
 
 	return logs, query.Find(&logs).Error
 }
+
+// Latest gets the latest memo log
+func (s *store) Latest(db *gorm.DB) (model.MemoLog, error) {
+	var log model.MemoLog
+	return log, db.Order("published_at DESC, title ASC").First(&log).Error
+}


### PR DESCRIPTION
#### What's this PR do?

- Accept non-discord author, every memo should be synced no matter what is the user name in the metadata. If we can find a related Discord account, post the announcement message with the Discord name. Otherwise, post the message with a bold memo username.
- Stream each item of the memo page, then compare with the latest synced memo instead of loading the entire DB to the memory as currently. 
- Ignore checking to publish date in the metadata, as long as the memo is not synced, it will be synced at this time.

![image](https://github.com/dwarvesf/fortress-api/assets/32956772/628f0c13-6091-45ec-b000-ca451fbad6c7)
