### PR TITLE
fix: newline is ignored when putting a space before it

### DIFF
--- a/pkg/service/discord/discord.go
+++ b/pkg/service/discord/discord.go
@@ -770,7 +770,7 @@ func (d *discordClient) SendWeeklyMemosMessage(guildID string, memos []model.Mem
 				authorField = "**@unknown-user**"
 			}
 
-			memolistString.WriteString(fmt.Sprintf("[[%v](%s)] %s - %v \n", idx+1, mem.URL, mem.Title, authorField))
+			memolistString.WriteString(fmt.Sprintf("[[%v](%s)] %s - %v\n", idx+1, mem.URL, mem.Title, authorField))
 		}
 
 		memolistString.WriteString("\n")


### PR DESCRIPTION
#### What's this PR do?

When putting a space before \n, the is may be interpreted as a space. In Discord embed, multiple spaces are automatically ignored.