### PR TITLE
fix: sync memo ignore folder is built as item

### DIFF
--- a/pkg/controller/memologs/sync.go
+++ b/pkg/controller/memologs/sync.go
@@ -73,6 +73,11 @@ func (c *controller) Sync() ([]model.MemoLog, error) {
 					continue
 				}
 
+				// Ignore folder is built as an item
+				if item.Description == "" && item.Author == "" {
+					continue
+				}
+
 				pubDate, _ := time.Parse(time.RFC1123Z, item.PubDate)
 				if pubDate.Before(last7days) {
 					stop = true


### PR DESCRIPTION
#### What's this PR do?

fix: sync memo ignore folder is built as item