### PR TITLE
feat: add GCS client creation for empty credentials

### DIFF
--- a/pkg/service/landingzone/google.go
+++ b/pkg/service/landingzone/google.go
@@ -22,6 +22,18 @@ type service struct {
 
 // New function return Google service
 func New(GCSCredentials string) (IService, error) {
+	if GCSCredentials == "" {
+		client, err := storage.NewClient(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %v", err)
+		}
+		return &service{
+			gcs: &CloudStorage{
+				client: client,
+			},
+		}, nil
+	}
+
 	decoded, err := base64.StdEncoding.DecodeString(GCSCredentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode gcs credentials: %v", err)


### PR DESCRIPTION
#### What's this PR do?

- [x] LD zone initializes Google Cloud Storage (GCS) with a default client. If a GCS service account is not explicitly declared, the zone uses a default client to interact with GCS. This allows users to read and write directly to GCS without the need for an internet connection, as long as the application is deployed into a Kubernetes.