### PR TITLE
fix: update memo sync

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -265,6 +265,10 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-05-12T23:16:24Z",
+      "resolved": "github:NixOS/nixpkgs/2e1da60850ce8159db9654a969c2c683f41c18b5?lastModified=1747091784&narHash=sha256-%2F2jlDI5%2BDfAbxdluamyRsORHueBYUiQh%2BaK%2FkshSvmE%3D"
+    },
     "go-swag@1.8.4": {
       "last_modified": "2022-08-27T08:52:24Z",
       "resolved": "github:NixOS/nixpkgs/ed0fab06cc1ca9799e6dda30529c963b95c4dc2a#go-swag",

--- a/pkg/controller/memologs/sweep.go
+++ b/pkg/controller/memologs/sweep.go
@@ -1,78 +1,74 @@
 package memologs
 
-import (
-	"encoding/xml"
-	"net/http"
-	"strings"
-
-	"github.com/dwarvesf/fortress-api/pkg/model"
-)
-
+// TODO: deprecated, now memo have no author - 16 May 2025
 func (c *controller) Sweep() error {
-	// List memo logs without authors
-	memoLogs, err := c.store.MemoLog.ListNonAuthor(c.repo.DB())
-	if err != nil {
-		return err
-	}
-
-	// Fetch memo data from the RSS feed
-	resp, err := http.Get(dfMemoRssURL)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	var feed struct {
-		Items []struct {
-			Link   string `xml:"link"`
-			Author string `xml:"author"`
-		} `xml:"channel>item"`
-	}
-
-	if err := xml.NewDecoder(resp.Body).Decode(&feed); err != nil {
-		return err
-	}
-
-	memoData := make(map[string][]string)
-	for _, item := range feed.Items {
-		authors := strings.Split(item.Author, ",")
-		for i := 0; i < len(authors); i++ {
-			authors[i] = strings.TrimSpace(authors[i])
-			if authors[i] == "" {
-				authors = append(authors[:i], authors[i+1:]...)
-				i--
-			}
-		}
-
-		if len(authors) == 0 {
-			continue
-		}
-		memoData[item.Link] = authors
-	}
-
-	// Process each memo log
-	for _, memoLog := range memoLogs {
-		usernames := memoData[memoLog.URL]
-		if len(usernames) == 0 {
-			continue
-		}
-
-		// Fetch Discord accounts for the usernames
-		discordAccounts, err := c.store.DiscordAccount.ListByMemoUsername(c.repo.DB(), usernames)
-		if err != nil {
-			return err
-		}
-
-		// Create memo authors
-		for _, discordAccount := range discordAccounts {
-			memoAuthor := &model.MemoAuthor{
-				MemoLogID:        memoLog.ID,
-				DiscordAccountID: discordAccount.ID,
-			}
-			if err := c.store.MemoLog.CreateMemoAuthor(c.repo.DB(), memoAuthor); err != nil {
-				return err
-			}
-		}
-	}
+	c.logger.Warn("deprecated, now memo have no author - 16 May 2025")
 	return nil
+
+	// List memo logs without authors
+	// memoLogs, err := c.store.MemoLog.ListNonAuthor(c.repo.DB())
+	// if err != nil {
+	// 	return err
+	// }
+
+	// // Fetch memo data from the RSS feed
+	// resp, err := http.Get(dfMemoRssURL)
+	// if err != nil {
+	// 	return err
+	// }
+	// defer resp.Body.Close()
+
+	// var feed struct {
+	// 	Items []struct {
+	// 		Link   string `xml:"link"`
+	// 		Author string `xml:"author"`
+	// 	} `xml:"channel>item"`
+	// }
+
+	// if err := xml.NewDecoder(resp.Body).Decode(&feed); err != nil {
+	// 	return err
+	// }
+
+	// memoData := make(map[string][]string)
+	// for _, item := range feed.Items {
+	// 	authors := strings.Split(item.Author, ",")
+	// 	for i := 0; i < len(authors); i++ {
+	// 		authors[i] = strings.TrimSpace(authors[i])
+	// 		if authors[i] == "" {
+	// 			authors = append(authors[:i], authors[i+1:]...)
+	// 			i--
+	// 		}
+	// 	}
+
+	// 	if len(authors) == 0 {
+	// 		continue
+	// 	}
+	// 	memoData[item.Link] = authors
+	// }
+
+	// // Process each memo log
+	// for _, memoLog := range memoLogs {
+	// 	usernames := memoData[memoLog.URL]
+	// 	if len(usernames) == 0 {
+	// 		continue
+	// 	}
+
+	// 	// Fetch Discord accounts for the usernames
+	// 	discordAccounts, err := c.store.DiscordAccount.ListByMemoUsername(c.repo.DB(), usernames)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+
+	// 	// Create memo authors
+	// 	for _, discordAccount := range discordAccounts {
+	// 		memoAuthor := &model.MemoAuthor{
+	// 			MemoLogID:        memoLog.ID,
+	// 			DiscordAccountID: discordAccount.ID,
+	// 		}
+	// 		if err := c.store.MemoLog.CreateMemoAuthor(c.repo.DB(), memoAuthor); err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
+	// return nil
 }

--- a/pkg/handler/auth/auth.go
+++ b/pkg/handler/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/k0kubun/pp/v3"
 
 	"github.com/dwarvesf/fortress-api/pkg/config"
 	"github.com/dwarvesf/fortress-api/pkg/controller"
@@ -145,7 +144,6 @@ func (h *handler) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
-	pp.Println("key created")
 	c.JSON(http.StatusOK, view.CreateResponse[any](&view.APIKeyData{
 		Key: key,
 	}, nil, nil, nil, ""))


### PR DESCRIPTION
# Update Memo Sync System

## Overview
This PR updates the memo synchronization system to improve handling of memo content and notifications. The changes focus on better content parsing, enhanced Discord notifications, and deprecation of author-based sweeping.

## Key Changes

### Memo Sync Improvements
- Improved title extraction with fallback to URL-based title generation
- Enhanced content parsing with CDATA handling
- Better description extraction with fallback to first non-header paragraph from content
- Updated memo model to use creator instead of multiple authors
- Added tags field based on memo category

### Discord Integration
- Redesigned memo notifications in Discord with embedded messages
- Added visual elements (thumbnail) to memo notifications
- Improved message formatting with better readability
- Limited description length to 300 characters with ellipsis

### Technical Updates
- Deprecated the memo sweep functionality (no longer needed as memos don't have authors)
- Updated XML parsing structure for RSS feed items
- Added better error handling for date parsing
- Removed debug print statements from auth handler
- Updated devbox dependencies

## Testing
Please verify:
- Memo synchronization with various content formats
- Discord notifications appearance and formatting
- Handling of memos with missing or malformed fields

## Migration Notes
The sweep functionality is now deprecated as of May 16, 2025, due to the removal of author-based memo structure.