### PR TITLE
feat: add timesheet API endpoints for Discord bot integration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -262,6 +262,7 @@ type NotionDatabase struct {
 	Issue             string
 	Contractor        string
 	DeploymentTracker string
+	Timesheet         string
 }
 
 type Discord struct {
@@ -495,6 +496,7 @@ func Generate(v ENV) *Config {
 				Issue:           v.GetString("NOTION_ISSUE_DB_ID"),
 				Contractor:        v.GetString("NOTION_CONTRACTOR_DB_ID"),
 				DeploymentTracker: v.GetString("NOTION_DEPLOYMENT_TRACKER_DB_ID"),
+				Timesheet:         v.GetString("NOTION_TIMESHEET_DB_ID"),
 			},
 		},
 		Discord: Discord{

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dwarvesf/fortress-api/pkg/handler/profile"
 	"github.com/dwarvesf/fortress-api/pkg/handler/project"
 	"github.com/dwarvesf/fortress-api/pkg/handler/survey"
+	"github.com/dwarvesf/fortress-api/pkg/handler/timesheet"
 	"github.com/dwarvesf/fortress-api/pkg/handler/valuation"
 	"github.com/dwarvesf/fortress-api/pkg/handler/vault"
 	"github.com/dwarvesf/fortress-api/pkg/handler/webhook"
@@ -79,6 +80,7 @@ type Handler struct {
 	News           news.IHandler
 	Youtube        yt.IHandler
 	DynamicEvents  dynamicevents.IHandler
+	Timesheet      timesheet.IHandler
 }
 
 func New(store *store.Store, repo store.DBRepo, service *service.Service, ctrl *controller.Controller, worker *worker.Worker, logger logger.Logger, cfg *config.Config) *Handler {
@@ -117,5 +119,6 @@ func New(store *store.Store, repo store.DBRepo, service *service.Service, ctrl *
 		News:           news.New(store, repo, ctrl, logger, cfg),
 		Youtube:        yt.New(ctrl, store, repo, service, logger, cfg),
 		DynamicEvents:  dynamicevents.New(store, repo, ctrl, logger, cfg, service),
+		Timesheet:      timesheet.New(ctrl, store, repo, service, logger, cfg),
 	}
 }

--- a/pkg/handler/timesheet/errs/errors.go
+++ b/pkg/handler/timesheet/errs/errors.go
@@ -1,0 +1,16 @@
+package errs
+
+import "errors"
+
+var (
+	ErrEmptyDiscordID      = errors.New("discord_id is required")
+	ErrEmptyProjectID      = errors.New("project_id is required")
+	ErrEmptyDate           = errors.New("date is required")
+	ErrEmptyTaskType       = errors.New("task_type is required")
+	ErrInvalidHours        = errors.New("hours must be between 0 and 24")
+	ErrEmptyProofOfWorks   = errors.New("proof_of_works is required")
+	ErrInvalidTaskType     = errors.New("task_type must be Development, Design, or Meeting")
+	ErrFutureDate          = errors.New("date cannot be in the future")
+	ErrContractorNotFound  = errors.New("contractor not found for discord ID")
+	ErrTimesheetDBNotFound = errors.New("timesheet database not configured")
+)

--- a/pkg/handler/timesheet/interface.go
+++ b/pkg/handler/timesheet/interface.go
@@ -1,0 +1,14 @@
+package timesheet
+
+import "github.com/gin-gonic/gin"
+
+type IHandler interface {
+	// LogHours creates a new timesheet entry
+	LogHours(c *gin.Context)
+
+	// GetEntries retrieves timesheet entries for a user
+	GetEntries(c *gin.Context)
+
+	// GetWeeklySummary retrieves weekly summary for a user
+	GetWeeklySummary(c *gin.Context)
+}

--- a/pkg/handler/timesheet/request/request.go
+++ b/pkg/handler/timesheet/request/request.go
@@ -1,0 +1,70 @@
+package request
+
+import (
+	"time"
+
+	"github.com/dwarvesf/fortress-api/pkg/handler/timesheet/errs"
+)
+
+// LogHoursRequest represents the request body for logging hours
+type LogHoursRequest struct {
+	DiscordID    string    `json:"discord_id" binding:"required"`
+	ProjectID    string    `json:"project_id" binding:"required"`
+	Date         time.Time `json:"date" binding:"required"`
+	TaskType     string    `json:"task_type" binding:"required"` // Development, Design, Meeting
+	Hours        float64   `json:"hours" binding:"required"`
+	ProofOfWorks string    `json:"proof_of_works" binding:"required"`
+	TaskOrderID  string    `json:"task_order_id"` // Optional
+}
+
+// Validate validates the request
+func (r LogHoursRequest) Validate() error {
+	if r.DiscordID == "" {
+		return errs.ErrEmptyDiscordID
+	}
+	if r.ProjectID == "" {
+		return errs.ErrEmptyProjectID
+	}
+	if r.Date.IsZero() {
+		return errs.ErrEmptyDate
+	}
+	if r.TaskType == "" {
+		return errs.ErrEmptyTaskType
+	}
+	if r.Hours <= 0 || r.Hours > 24 {
+		return errs.ErrInvalidHours
+	}
+	if r.ProofOfWorks == "" {
+		return errs.ErrEmptyProofOfWorks
+	}
+
+	// Validate TaskType is one of allowed values
+	validTaskTypes := map[string]bool{
+		"Development": true,
+		"Design":      true,
+		"Meeting":     true,
+	}
+	if !validTaskTypes[r.TaskType] {
+		return errs.ErrInvalidTaskType
+	}
+
+	// Don't allow future dates
+	if r.Date.After(time.Now().AddDate(0, 0, 1)) {
+		return errs.ErrFutureDate
+	}
+
+	return nil
+}
+
+// GetEntriesRequest represents query parameters for getting entries
+type GetEntriesRequest struct {
+	DiscordID string `form:"discord_id" binding:"required"`
+	StartDate string `form:"start_date"` // YYYY-MM-DD format
+	EndDate   string `form:"end_date"`   // YYYY-MM-DD format
+}
+
+// GetWeeklySummaryRequest represents query parameters for weekly summary
+type GetWeeklySummaryRequest struct {
+	DiscordID  string `form:"discord_id" binding:"required"`
+	WeekOffset int    `form:"week_offset"` // 0=current, -1=last week, etc.
+}

--- a/pkg/handler/timesheet/timesheet.go
+++ b/pkg/handler/timesheet/timesheet.go
@@ -1,0 +1,311 @@
+package timesheet
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/dwarvesf/fortress-api/pkg/config"
+	"github.com/dwarvesf/fortress-api/pkg/controller"
+	"github.com/dwarvesf/fortress-api/pkg/handler/timesheet/errs"
+	"github.com/dwarvesf/fortress-api/pkg/handler/timesheet/request"
+	"github.com/dwarvesf/fortress-api/pkg/logger"
+	"github.com/dwarvesf/fortress-api/pkg/service"
+	notionSvc "github.com/dwarvesf/fortress-api/pkg/service/notion"
+	"github.com/dwarvesf/fortress-api/pkg/store"
+	"github.com/dwarvesf/fortress-api/pkg/view"
+)
+
+type handler struct {
+	store      *store.Store
+	service    *service.Service
+	logger     logger.Logger
+	repo       store.DBRepo
+	config     *config.Config
+	controller *controller.Controller
+}
+
+// New returns a handler
+func New(controller *controller.Controller, store *store.Store, repo store.DBRepo, service *service.Service, logger logger.Logger, cfg *config.Config) IHandler {
+	return &handler{
+		store:      store,
+		repo:       repo,
+		service:    service,
+		logger:     logger,
+		config:     cfg,
+		controller: controller,
+	}
+}
+
+// LogHours godoc
+// @Summary Log timesheet hours
+// @Description Create a new timesheet entry in Notion
+// @Tags Timesheet
+// @Accept json
+// @Produce json
+// @Param body body request.LogHoursRequest true "Timesheet entry details"
+// @Success 200 {object} view.TimesheetEntryResponse
+// @Failure 400 {object} view.ErrorResponse
+// @Failure 500 {object} view.ErrorResponse
+// @Router /timesheets [post]
+func (h *handler) LogHours(c *gin.Context) {
+	l := h.logger.Fields(logger.Fields{
+		"handler": "timesheet",
+		"method":  "LogHours",
+	})
+
+	var req request.LogHoursRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		l.Error(err, "failed to bind request")
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, req, "invalid request"))
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		l.Errorf(err, "validation failed", "body", req)
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, req, ""))
+		return
+	}
+
+	// Create timesheet service
+	timesheetService := notionSvc.NewTimesheetService(h.config, h.store, h.repo, h.logger)
+	if timesheetService == nil {
+		l.Error(errors.New("failed to create timesheet service"), "notion secret may not be configured")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, errs.ErrTimesheetDBNotFound, nil, ""))
+		return
+	}
+
+	// Find contractor by Discord ID
+	contractorID, err := timesheetService.GetContractorPageIDByDiscordID(c.Request.Context(), req.DiscordID)
+	if err != nil {
+		l.Error(err, "failed to find contractor")
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, errs.ErrContractorNotFound, nil,
+			"contractor not found for Discord ID: "+req.DiscordID))
+		return
+	}
+
+	// Create timesheet entry
+	entry := notionSvc.TimesheetEntry{
+		ProjectID:    req.ProjectID,
+		ContractorID: contractorID,
+		Date:         &req.Date,
+		TaskType:     req.TaskType,
+		Hours:        req.Hours,
+		ProofOfWorks: req.ProofOfWorks,
+		TaskOrderID:  req.TaskOrderID,
+	}
+
+	pageID, err := timesheetService.CreateTimesheetEntry(c.Request.Context(), entry)
+	if err != nil {
+		l.Error(err, "failed to create timesheet entry")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, "failed to log hours"))
+		return
+	}
+
+	entry.PageID = pageID
+	c.JSON(http.StatusOK, view.CreateResponse(
+		view.ToTimesheetEntry(entry),
+		nil, nil, nil,
+		"timesheet entry created successfully",
+	))
+}
+
+// GetEntries godoc
+// @Summary Get timesheet entries
+// @Description Retrieve timesheet entries for a user by Discord ID
+// @Tags Timesheet
+// @Accept json
+// @Produce json
+// @Param discord_id query string true "Discord ID"
+// @Param start_date query string false "Start date (YYYY-MM-DD)"
+// @Param end_date query string false "End date (YYYY-MM-DD)"
+// @Success 200 {object} view.TimesheetEntriesResponse
+// @Failure 400 {object} view.ErrorResponse
+// @Failure 500 {object} view.ErrorResponse
+// @Router /timesheets [get]
+func (h *handler) GetEntries(c *gin.Context) {
+	l := h.logger.Fields(logger.Fields{
+		"handler": "timesheet",
+		"method":  "GetEntries",
+	})
+
+	discordID := c.Query("discord_id")
+	if discordID == "" {
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil,
+			errs.ErrEmptyDiscordID, nil, ""))
+		return
+	}
+
+	var startDate, endDate *time.Time
+	if sd := c.Query("start_date"); sd != "" {
+		t, err := time.Parse("2006-01-02", sd)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, nil, "invalid start_date format"))
+			return
+		}
+		startDate = &t
+	}
+
+	if ed := c.Query("end_date"); ed != "" {
+		t, err := time.Parse("2006-01-02", ed)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, nil, "invalid end_date format"))
+			return
+		}
+		endDate = &t
+	}
+
+	// Create timesheet service
+	timesheetService := notionSvc.NewTimesheetService(h.config, h.store, h.repo, h.logger)
+	if timesheetService == nil {
+		l.Error(errors.New("failed to create timesheet service"), "notion secret may not be configured")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, errs.ErrTimesheetDBNotFound, nil, ""))
+		return
+	}
+
+	// Get Discord username from Discord ID for querying Notion
+	discordUsername, err := h.getDiscordUsername(c, discordID)
+	if err != nil {
+		l.Error(err, "failed to get discord username")
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, nil, "discord user not found"))
+		return
+	}
+
+	entries, err := timesheetService.QueryTimesheetByDiscord(
+		c.Request.Context(),
+		discordUsername,
+		startDate,
+		endDate,
+	)
+	if err != nil {
+		l.Error(err, "failed to query timesheet entries")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	c.JSON(http.StatusOK, view.CreateResponse(
+		view.ToTimesheetEntries(entries),
+		nil, nil, nil,
+		"entries retrieved successfully",
+	))
+}
+
+// GetWeeklySummary godoc
+// @Summary Get weekly timesheet summary
+// @Description Retrieve weekly hours summary for a user
+// @Tags Timesheet
+// @Accept json
+// @Produce json
+// @Param discord_id query string true "Discord ID"
+// @Param week_offset query int false "Week offset from current week (0=current, -1=last week)"
+// @Success 200 {object} view.TimesheetWeeklySummaryResponse
+// @Failure 400 {object} view.ErrorResponse
+// @Failure 500 {object} view.ErrorResponse
+// @Router /timesheets/weekly-summary [get]
+func (h *handler) GetWeeklySummary(c *gin.Context) {
+	l := h.logger.Fields(logger.Fields{
+		"handler": "timesheet",
+		"method":  "GetWeeklySummary",
+	})
+
+	discordID := c.Query("discord_id")
+	if discordID == "" {
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil,
+			errs.ErrEmptyDiscordID, nil, ""))
+		return
+	}
+
+	// Calculate week boundaries
+	weekOffset := 0
+	if wo := c.Query("week_offset"); wo != "" {
+		if parsed, err := strconv.Atoi(wo); err == nil {
+			weekOffset = parsed
+		}
+	}
+
+	now := time.Now()
+	weekday := int(now.Weekday())
+	if weekday == 0 {
+		weekday = 7 // Sunday = 7
+	}
+
+	// Start of week (Monday)
+	startOfWeek := now.AddDate(0, 0, -(weekday-1)+(weekOffset*7))
+	startOfWeek = time.Date(startOfWeek.Year(), startOfWeek.Month(), startOfWeek.Day(), 0, 0, 0, 0, startOfWeek.Location())
+	endOfWeek := startOfWeek.AddDate(0, 0, 6)
+	endOfWeek = time.Date(endOfWeek.Year(), endOfWeek.Month(), endOfWeek.Day(), 23, 59, 59, 0, endOfWeek.Location())
+
+	// Create timesheet service
+	timesheetService := notionSvc.NewTimesheetService(h.config, h.store, h.repo, h.logger)
+	if timesheetService == nil {
+		l.Error(errors.New("failed to create timesheet service"), "notion secret may not be configured")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, errs.ErrTimesheetDBNotFound, nil, ""))
+		return
+	}
+
+	// Get Discord username from Discord ID for querying Notion
+	discordUsername, err := h.getDiscordUsername(c, discordID)
+	if err != nil {
+		l.Error(err, "failed to get discord username")
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, nil, err, nil, "discord user not found"))
+		return
+	}
+
+	entries, err := timesheetService.QueryTimesheetByDiscord(
+		c.Request.Context(),
+		discordUsername,
+		&startOfWeek,
+		&endOfWeek,
+	)
+	if err != nil {
+		l.Error(err, "failed to query timesheet entries")
+		c.JSON(http.StatusInternalServerError, view.CreateResponse[any](nil, nil, err, nil, ""))
+		return
+	}
+
+	// Calculate summary
+	summary := calculateWeeklySummary(entries, startOfWeek, endOfWeek)
+
+	c.JSON(http.StatusOK, view.CreateResponse(summary, nil, nil, nil, "weekly summary retrieved"))
+}
+
+// getDiscordUsername retrieves Discord username from Discord ID
+func (h *handler) getDiscordUsername(c *gin.Context, discordID string) (string, error) {
+	var discordAccount struct {
+		DiscordUsername string
+	}
+	err := h.repo.DB().WithContext(c.Request.Context()).
+		Table("discord_accounts").
+		Select("discord_username").
+		Where("discord_id = ? AND deleted_at IS NULL", discordID).
+		First(&discordAccount).Error
+	if err != nil {
+		return "", err
+	}
+	return discordAccount.DiscordUsername, nil
+}
+
+// calculateWeeklySummary calculates aggregated weekly summary from entries
+func calculateWeeklySummary(entries []notionSvc.TimesheetEntry, startOfWeek, endOfWeek time.Time) view.TimesheetWeeklySummary {
+	summary := view.TimesheetWeeklySummary{
+		StartDate:  startOfWeek,
+		EndDate:    endOfWeek,
+		TotalHours: 0,
+		ByTaskType: make(map[string]float64),
+		ByProject:  make(map[string]float64),
+		EntryCount: len(entries),
+	}
+
+	for _, entry := range entries {
+		summary.TotalHours += entry.Hours
+		summary.ByTaskType[entry.TaskType] += entry.Hours
+		if entry.ProjectID != "" {
+			summary.ByProject[entry.ProjectID] += entry.Hours
+		}
+	}
+
+	return summary
+}

--- a/pkg/handler/timesheet/timesheet_test.go
+++ b/pkg/handler/timesheet/timesheet_test.go
@@ -1,0 +1,383 @@
+package timesheet
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dwarvesf/fortress-api/pkg/handler/timesheet/request"
+	notionSvc "github.com/dwarvesf/fortress-api/pkg/service/notion"
+	"github.com/dwarvesf/fortress-api/pkg/view"
+)
+
+func TestLogHoursRequestValidation(t *testing.T) {
+	validDate := time.Now().AddDate(0, 0, -1) // yesterday
+
+	tests := []struct {
+		name        string
+		request     request.LogHoursRequest
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid_request",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        6.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty_discord_id",
+			request: request.LogHoursRequest{
+				DiscordID:    "",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        6.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "discord_id is required",
+		},
+		{
+			name: "empty_project_id",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        6.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "project_id is required",
+		},
+		{
+			name: "invalid_hours_zero",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "hours must be between 0 and 24",
+		},
+		{
+			name: "invalid_hours_over_24",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        25.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "hours must be between 0 and 24",
+		},
+		{
+			name: "invalid_task_type",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "InvalidType",
+				Hours:        6.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "task_type must be Development, Design, or Meeting",
+		},
+		{
+			name: "valid_design_task_type",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Design",
+				Hours:        2.5,
+				ProofOfWorks: "Figma link",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid_meeting_task_type",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Meeting",
+				Hours:        0.5,
+				ProofOfWorks: "Standup meeting",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty_proof_of_works",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         validDate,
+				TaskType:     "Development",
+				Hours:        6.0,
+				ProofOfWorks: "",
+			},
+			expectError: true,
+			errorMsg:    "proof_of_works is required",
+		},
+		{
+			name: "future_date",
+			request: request.LogHoursRequest{
+				DiscordID:    "123456789",
+				ProjectID:    "project-uuid",
+				Date:         time.Now().AddDate(0, 0, 7), // 7 days in future
+				TaskType:     "Development",
+				Hours:        6.0,
+				ProofOfWorks: "PR #123",
+			},
+			expectError: true,
+			errorMsg:    "date cannot be in the future",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCalculateWeeklySummary(t *testing.T) {
+	startOfWeek := time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC) // Monday
+	endOfWeek := time.Date(2025, 12, 21, 23, 59, 59, 0, time.UTC) // Sunday
+
+	tests := []struct {
+		name           string
+		entries        []notionSvc.TimesheetEntry
+		expectedTotal  float64
+		expectedCount  int
+		expectedByType map[string]float64
+	}{
+		{
+			name:           "empty_entries",
+			entries:        []notionSvc.TimesheetEntry{},
+			expectedTotal:  0,
+			expectedCount:  0,
+			expectedByType: map[string]float64{},
+		},
+		{
+			name: "single_entry",
+			entries: []notionSvc.TimesheetEntry{
+				{Hours: 6.0, TaskType: "Development", ProjectID: "proj1"},
+			},
+			expectedTotal:  6.0,
+			expectedCount:  1,
+			expectedByType: map[string]float64{"Development": 6.0},
+		},
+		{
+			name: "multiple_entries_same_type",
+			entries: []notionSvc.TimesheetEntry{
+				{Hours: 6.0, TaskType: "Development", ProjectID: "proj1"},
+				{Hours: 4.0, TaskType: "Development", ProjectID: "proj1"},
+			},
+			expectedTotal:  10.0,
+			expectedCount:  2,
+			expectedByType: map[string]float64{"Development": 10.0},
+		},
+		{
+			name: "multiple_entries_different_types",
+			entries: []notionSvc.TimesheetEntry{
+				{Hours: 6.0, TaskType: "Development", ProjectID: "proj1"},
+				{Hours: 2.0, TaskType: "Design", ProjectID: "proj1"},
+				{Hours: 0.5, TaskType: "Meeting", ProjectID: "proj1"},
+			},
+			expectedTotal:  8.5,
+			expectedCount:  3,
+			expectedByType: map[string]float64{"Development": 6.0, "Design": 2.0, "Meeting": 0.5},
+		},
+		{
+			name: "fractional_hours",
+			entries: []notionSvc.TimesheetEntry{
+				{Hours: 2.5, TaskType: "Development", ProjectID: "proj1"},
+				{Hours: 1.25, TaskType: "Development", ProjectID: "proj1"},
+			},
+			expectedTotal:  3.75,
+			expectedCount:  2,
+			expectedByType: map[string]float64{"Development": 3.75},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := calculateWeeklySummary(tt.entries, startOfWeek, endOfWeek)
+
+			assert.Equal(t, tt.expectedTotal, summary.TotalHours)
+			assert.Equal(t, tt.expectedCount, summary.EntryCount)
+			assert.Equal(t, startOfWeek, summary.StartDate)
+			assert.Equal(t, endOfWeek, summary.EndDate)
+
+			for taskType, expectedHours := range tt.expectedByType {
+				assert.Equal(t, expectedHours, summary.ByTaskType[taskType], "ByTaskType[%s]", taskType)
+			}
+		})
+	}
+}
+
+func TestWeekBoundaryCalculation(t *testing.T) {
+	tests := []struct {
+		name              string
+		now               time.Time
+		weekOffset        int
+		expectedStartDay  int
+		expectedStartMonth time.Month
+		expectedEndDay    int
+	}{
+		{
+			name:              "current_week_wednesday",
+			now:               time.Date(2025, 12, 17, 12, 0, 0, 0, time.UTC), // Wednesday
+			weekOffset:        0,
+			expectedStartDay:  15, // Monday
+			expectedStartMonth: time.December,
+			expectedEndDay:    21, // Sunday
+		},
+		{
+			name:              "current_week_monday",
+			now:               time.Date(2025, 12, 15, 12, 0, 0, 0, time.UTC), // Monday
+			weekOffset:        0,
+			expectedStartDay:  15,
+			expectedStartMonth: time.December,
+			expectedEndDay:    21,
+		},
+		{
+			name:              "current_week_sunday",
+			now:               time.Date(2025, 12, 21, 12, 0, 0, 0, time.UTC), // Sunday
+			weekOffset:        0,
+			expectedStartDay:  15,
+			expectedStartMonth: time.December,
+			expectedEndDay:    21,
+		},
+		{
+			name:              "last_week",
+			now:               time.Date(2025, 12, 17, 12, 0, 0, 0, time.UTC), // Wednesday
+			weekOffset:        -1,
+			expectedStartDay:  8,
+			expectedStartMonth: time.December,
+			expectedEndDay:    14,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			weekday := int(tt.now.Weekday())
+			if weekday == 0 {
+				weekday = 7 // Sunday = 7
+			}
+
+			// Start of week (Monday)
+			startOfWeek := tt.now.AddDate(0, 0, -(weekday-1)+(tt.weekOffset*7))
+			startOfWeek = time.Date(startOfWeek.Year(), startOfWeek.Month(), startOfWeek.Day(), 0, 0, 0, 0, startOfWeek.Location())
+			endOfWeek := startOfWeek.AddDate(0, 0, 6)
+
+			assert.Equal(t, tt.expectedStartDay, startOfWeek.Day(), "start day")
+			assert.Equal(t, tt.expectedStartMonth, startOfWeek.Month(), "start month")
+			assert.Equal(t, tt.expectedEndDay, endOfWeek.Day(), "end day")
+		})
+	}
+}
+
+func TestGetEntriesInvalidDiscordID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/timesheets", nil)
+
+	// Directly test the validation by checking query param
+	discordID := c.Query("discord_id")
+	assert.Empty(t, discordID, "discord_id should be empty when not provided")
+}
+
+func TestGetWeeklySummaryInvalidDiscordID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/timesheets/weekly-summary", nil)
+
+	// Directly test the validation by checking query param
+	discordID := c.Query("discord_id")
+	assert.Empty(t, discordID, "discord_id should be empty when not provided")
+}
+
+func TestLogHoursRequestBinding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Test that invalid JSON fails to bind
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/timesheets", strings.NewReader("invalid json"))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var req request.LogHoursRequest
+	err := c.ShouldBindJSON(&req)
+	assert.Error(t, err, "invalid JSON should fail to bind")
+}
+
+func TestToTimesheetEntry(t *testing.T) {
+	date := time.Date(2025, 12, 17, 0, 0, 0, 0, time.UTC)
+	entry := notionSvc.TimesheetEntry{
+		PageID:       "page-123",
+		ProjectID:    "proj-456",
+		ProjectName:  "Test Project",
+		Discord:      "testuser",
+		Date:         &date,
+		TaskType:     "Development",
+		Status:       "Approved",
+		Hours:        6.0,
+		ProofOfWorks: "PR #123",
+	}
+
+	viewEntry := view.ToTimesheetEntry(entry)
+
+	assert.Equal(t, entry.PageID, viewEntry.PageID)
+	assert.Equal(t, entry.ProjectID, viewEntry.ProjectID)
+	assert.Equal(t, entry.ProjectName, viewEntry.ProjectName)
+	assert.Equal(t, entry.Discord, viewEntry.Discord)
+	assert.Equal(t, entry.Date, viewEntry.Date)
+	assert.Equal(t, entry.TaskType, viewEntry.TaskType)
+	assert.Equal(t, entry.Status, viewEntry.Status)
+	assert.Equal(t, entry.Hours, viewEntry.Hours)
+	assert.Equal(t, entry.ProofOfWorks, viewEntry.ProofOfWorks)
+}
+
+func TestToTimesheetEntries(t *testing.T) {
+	date := time.Date(2025, 12, 17, 0, 0, 0, 0, time.UTC)
+	entries := []notionSvc.TimesheetEntry{
+		{PageID: "page-1", Hours: 6.0, Date: &date},
+		{PageID: "page-2", Hours: 4.0, Date: &date},
+	}
+
+	viewEntries := view.ToTimesheetEntries(entries)
+
+	assert.Len(t, viewEntries, 2)
+	assert.Equal(t, "page-1", viewEntries[0].PageID)
+	assert.Equal(t, "page-2", viewEntries[1].PageID)
+}

--- a/pkg/routes/v1.go
+++ b/pkg/routes/v1.go
@@ -395,6 +395,14 @@ func loadV1Routes(r *gin.Engine, h *handler.Handler, repo store.DBRepo, s *store
 		earnGroup.GET("", conditionalAuthMW, h.Earn.ListEarn)
 	}
 
+	// Timesheet API for fortress-discord
+	timesheetGroup := v1.Group("/timesheets")
+	{
+		timesheetGroup.POST("", conditionalAuthMW, h.Timesheet.LogHours)
+		timesheetGroup.GET("", conditionalAuthMW, h.Timesheet.GetEntries)
+		timesheetGroup.GET("/weekly-summary", conditionalAuthMW, h.Timesheet.GetWeeklySummary)
+	}
+
 	// Delivery metrics
 	{
 		deliveryGroup := v1.Group("/delivery-metrics")

--- a/pkg/service/notion/timesheet.go
+++ b/pkg/service/notion/timesheet.go
@@ -1,0 +1,345 @@
+package notion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	nt "github.com/dstotijn/go-notion"
+
+	"github.com/dwarvesf/fortress-api/pkg/config"
+	"github.com/dwarvesf/fortress-api/pkg/logger"
+	"github.com/dwarvesf/fortress-api/pkg/store"
+)
+
+// TimesheetEntry represents a timesheet entry from Notion
+type TimesheetEntry struct {
+	PageID       string     `json:"page_id"`
+	ProjectID    string     `json:"project_id"`    // Relation page ID
+	ProjectName  string     `json:"project_name"`  // For display
+	ContractorID string     `json:"contractor_id"` // Relation page ID
+	Discord      string     `json:"discord"`       // Discord username
+	Date         *time.Time `json:"date"`
+	TaskType     string     `json:"task_type"` // Development, Design, Meeting
+	Status       string     `json:"status"`    // Approved/Pending
+	Hours        float64    `json:"hours"`
+	ProofOfWorks string     `json:"proof_of_works"`
+	TaskOrderID  string     `json:"task_order_id"` // Optional relation
+}
+
+// TimesheetService handles timesheet operations with Notion
+type TimesheetService struct {
+	client *nt.Client
+	cfg    *config.Config
+	store  *store.Store
+	repo   store.DBRepo
+	logger logger.Logger
+}
+
+// NewTimesheetService creates a new Notion timesheet service
+func NewTimesheetService(cfg *config.Config, store *store.Store, repo store.DBRepo, logger logger.Logger) *TimesheetService {
+	if cfg.Notion.Secret == "" {
+		logger.Error(errors.New("notion secret not configured"), "notion secret is empty")
+		return nil
+	}
+
+	logger.Debug("creating new TimesheetService")
+
+	return &TimesheetService{
+		client: nt.NewClient(cfg.Notion.Secret),
+		cfg:    cfg,
+		store:  store,
+		repo:   repo,
+		logger: logger,
+	}
+}
+
+// CreateTimesheetEntry creates a new timesheet entry in Notion
+func (s *TimesheetService) CreateTimesheetEntry(ctx context.Context, entry TimesheetEntry) (string, error) {
+	if s.client == nil {
+		return "", errors.New("notion client is nil")
+	}
+
+	timesheetDBID := s.cfg.Notion.Databases.Timesheet
+	if timesheetDBID == "" {
+		return "", errors.New("timesheet database ID not configured")
+	}
+
+	s.logger.Debug(fmt.Sprintf("creating timesheet entry: project=%s discord=%s date=%v hours=%.2f",
+		entry.ProjectID, entry.Discord, entry.Date, entry.Hours))
+
+	// Build properties for Notion
+	props := nt.DatabasePageProperties{
+		"Project": nt.DatabasePageProperty{
+			Type:     nt.DBPropTypeRelation,
+			Relation: []nt.Relation{{ID: entry.ProjectID}},
+		},
+		"Contractor": nt.DatabasePageProperty{
+			Type:     nt.DBPropTypeRelation,
+			Relation: []nt.Relation{{ID: entry.ContractorID}},
+		},
+		"Task Type": nt.DatabasePageProperty{
+			Type:   nt.DBPropTypeSelect,
+			Select: &nt.SelectOptions{Name: entry.TaskType},
+		},
+		"Hours": nt.DatabasePageProperty{
+			Type:   nt.DBPropTypeNumber,
+			Number: &entry.Hours,
+		},
+		"Proof of Works": nt.DatabasePageProperty{
+			Type: nt.DBPropTypeRichText,
+			RichText: []nt.RichText{{
+				Type: nt.RichTextTypeText,
+				Text: &nt.Text{Content: entry.ProofOfWorks},
+			}},
+		},
+	}
+
+	// Add date if provided
+	if entry.Date != nil {
+		props["Date"] = nt.DatabasePageProperty{
+			Type: nt.DBPropTypeDate,
+			Date: &nt.Date{Start: nt.NewDateTime(*entry.Date, false)},
+		}
+	}
+
+	// Add optional Task Order relation
+	if entry.TaskOrderID != "" {
+		props["Task Order"] = nt.DatabasePageProperty{
+			Type:     nt.DBPropTypeRelation,
+			Relation: []nt.Relation{{ID: entry.TaskOrderID}},
+		}
+	}
+
+	page, err := s.client.CreatePage(ctx, nt.CreatePageParams{
+		ParentType:             nt.ParentTypeDatabase,
+		ParentID:               timesheetDBID,
+		DatabasePageProperties: &props,
+	})
+	if err != nil {
+		s.logger.Error(err, "failed to create timesheet entry in Notion")
+		return "", fmt.Errorf("failed to create timesheet entry: %w", err)
+	}
+
+	s.logger.Debug(fmt.Sprintf("created timesheet entry: page_id=%s", page.ID))
+	return page.ID, nil
+}
+
+// QueryTimesheetByDiscord queries timesheet entries by Discord username
+func (s *TimesheetService) QueryTimesheetByDiscord(
+	ctx context.Context,
+	discordUsername string,
+	startDate, endDate *time.Time,
+) ([]TimesheetEntry, error) {
+	if s.client == nil {
+		return nil, errors.New("notion client is nil")
+	}
+
+	timesheetDBID := s.cfg.Notion.Databases.Timesheet
+	if timesheetDBID == "" {
+		return nil, errors.New("timesheet database ID not configured")
+	}
+
+	s.logger.Debug(fmt.Sprintf("querying timesheet entries: discord=%s start=%v end=%v",
+		discordUsername, startDate, endDate))
+
+	// Build filter for Discord username
+	filters := []nt.DatabaseQueryFilter{
+		{
+			Property: "Discord",
+			DatabaseQueryPropertyFilter: nt.DatabaseQueryPropertyFilter{
+				RichText: &nt.TextPropertyFilter{
+					Contains: discordUsername,
+				},
+			},
+		},
+	}
+
+	// Add date range filters
+	if startDate != nil {
+		filters = append(filters, nt.DatabaseQueryFilter{
+			Property: "Date",
+			DatabaseQueryPropertyFilter: nt.DatabaseQueryPropertyFilter{
+				Date: &nt.DatePropertyFilter{
+					OnOrAfter: startDate,
+				},
+			},
+		})
+	}
+
+	if endDate != nil {
+		filters = append(filters, nt.DatabaseQueryFilter{
+			Property: "Date",
+			DatabaseQueryPropertyFilter: nt.DatabaseQueryPropertyFilter{
+				Date: &nt.DatePropertyFilter{
+					OnOrBefore: endDate,
+				},
+			},
+		})
+	}
+
+	filter := &nt.DatabaseQueryFilter{And: filters}
+
+	resp, err := s.client.QueryDatabase(ctx, timesheetDBID, &nt.DatabaseQuery{
+		Filter: filter,
+		Sorts: []nt.DatabaseQuerySort{
+			{Property: "Date", Direction: nt.SortDirDesc},
+		},
+	})
+	if err != nil {
+		s.logger.Error(err, "failed to query timesheet entries from Notion")
+		return nil, fmt.Errorf("failed to query timesheet: %w", err)
+	}
+
+	// Parse results into TimesheetEntry structs
+	entries := make([]TimesheetEntry, 0, len(resp.Results))
+	for _, page := range resp.Results {
+		props, ok := page.Properties.(nt.DatabasePageProperties)
+		if !ok {
+			continue
+		}
+		entry := s.parseTimesheetPage(page.ID, props)
+		entries = append(entries, entry)
+	}
+
+	s.logger.Debug(fmt.Sprintf("found %d timesheet entries for discord=%s", len(entries), discordUsername))
+	return entries, nil
+}
+
+// GetContractorPageIDByDiscordID looks up a contractor page ID by Discord ID
+// It uses the existing pattern: discord_accounts -> employees -> Notion Contractor DB
+func (s *TimesheetService) GetContractorPageIDByDiscordID(ctx context.Context, discordID string) (string, error) {
+	s.logger.Debug(fmt.Sprintf("looking up contractor by Discord ID: %s", discordID))
+
+	// 1. Look up discord_accounts table to get the employee's team email
+	var discordAccount struct {
+		ID string
+	}
+	err := s.repo.DB().WithContext(ctx).
+		Table("discord_accounts").
+		Select("id").
+		Where("discord_id = ? AND deleted_at IS NULL", discordID).
+		First(&discordAccount).Error
+	if err != nil {
+		s.logger.Debug(fmt.Sprintf("discord account not found for discord_id: %s, error: %v", discordID, err))
+		return "", fmt.Errorf("discord account not found: %w", err)
+	}
+
+	s.logger.Debug(fmt.Sprintf("found discord account: discord_id=%s account_id=%s", discordID, discordAccount.ID))
+
+	// 2. Look up employees table by discord_account_id to get team_email
+	var employee struct {
+		TeamEmail string
+	}
+	err = s.repo.DB().WithContext(ctx).
+		Table("employees").
+		Select("team_email").
+		Where("discord_account_id = ? AND deleted_at IS NULL", discordAccount.ID).
+		First(&employee).Error
+	if err != nil {
+		s.logger.Debug(fmt.Sprintf("employee not found for discord_account_id: %s, error: %v", discordAccount.ID, err))
+		return "", fmt.Errorf("employee not found for discord account: %w", err)
+	}
+
+	s.logger.Debug(fmt.Sprintf("found employee: discord_account_id=%s team_email=%s", discordAccount.ID, employee.TeamEmail))
+
+	// 3. Query Notion Contractor database by Team Email
+	contractorDBID := s.cfg.Notion.Databases.Contractor
+	if contractorDBID == "" {
+		return "", errors.New("contractor database ID not configured")
+	}
+
+	filter := &nt.DatabaseQueryFilter{
+		Property: "Team Email",
+		DatabaseQueryPropertyFilter: nt.DatabaseQueryPropertyFilter{
+			Email: &nt.TextPropertyFilter{
+				Equals: employee.TeamEmail,
+			},
+		},
+	}
+
+	resp, err := s.client.QueryDatabase(ctx, contractorDBID, &nt.DatabaseQuery{
+		Filter:   filter,
+		PageSize: 1,
+	})
+	if err != nil {
+		s.logger.Error(err, fmt.Sprintf("failed to query contractor database: email=%s", employee.TeamEmail))
+		return "", fmt.Errorf("failed to query contractor database: %w", err)
+	}
+
+	if len(resp.Results) == 0 {
+		s.logger.Debug(fmt.Sprintf("no contractor found for email: %s", employee.TeamEmail))
+		return "", fmt.Errorf("contractor not found for email: %s", employee.TeamEmail)
+	}
+
+	contractorPageID := resp.Results[0].ID
+	s.logger.Debug(fmt.Sprintf("found contractor page: email=%s page_id=%s", employee.TeamEmail, contractorPageID))
+	return contractorPageID, nil
+}
+
+// parseTimesheetPage parses a Notion page into a TimesheetEntry
+func (s *TimesheetService) parseTimesheetPage(pageID string, props nt.DatabasePageProperties) TimesheetEntry {
+	entry := TimesheetEntry{PageID: pageID}
+
+	// Parse Hours
+	if prop, ok := props["Hours"]; ok && prop.Number != nil {
+		entry.Hours = *prop.Number
+	}
+
+	// Parse Date
+	if prop, ok := props["Date"]; ok && prop.Date != nil {
+		t := prop.Date.Start.Time
+		if !t.IsZero() {
+			entry.Date = &t
+		}
+	}
+
+	// Parse Task Type
+	if prop, ok := props["Task Type"]; ok && prop.Select != nil {
+		entry.TaskType = prop.Select.Name
+	}
+
+	// Parse Status
+	if prop, ok := props["Status"]; ok && prop.Status != nil {
+		entry.Status = prop.Status.Name
+	}
+
+	// Parse Discord (rich text or rollup)
+	if prop, ok := props["Discord"]; ok {
+		if len(prop.RichText) > 0 {
+			var parts []string
+			for _, rt := range prop.RichText {
+				parts = append(parts, rt.PlainText)
+			}
+			entry.Discord = strings.Join(parts, "")
+		}
+	}
+
+	// Parse Proof of Works
+	if prop, ok := props["Proof of Works"]; ok && len(prop.RichText) > 0 {
+		var parts []string
+		for _, rt := range prop.RichText {
+			parts = append(parts, rt.PlainText)
+		}
+		entry.ProofOfWorks = strings.Join(parts, "")
+	}
+
+	// Parse Project relation
+	if prop, ok := props["Project"]; ok && len(prop.Relation) > 0 {
+		entry.ProjectID = prop.Relation[0].ID
+	}
+
+	// Parse Contractor relation
+	if prop, ok := props["Contractor"]; ok && len(prop.Relation) > 0 {
+		entry.ContractorID = prop.Relation[0].ID
+	}
+
+	// Parse Task Order relation
+	if prop, ok := props["Task Order"]; ok && len(prop.Relation) > 0 {
+		entry.TaskOrderID = prop.Relation[0].ID
+	}
+
+	return entry
+}

--- a/pkg/view/timesheet.go
+++ b/pkg/view/timesheet.go
@@ -1,0 +1,54 @@
+package view
+
+import (
+	"time"
+
+	notionSvc "github.com/dwarvesf/fortress-api/pkg/service/notion"
+)
+
+// TimesheetEntry represents a timesheet entry in API responses
+type TimesheetEntry struct {
+	PageID       string     `json:"page_id"`
+	ProjectID    string     `json:"project_id"`
+	ProjectName  string     `json:"project_name,omitempty"`
+	Discord      string     `json:"discord"`
+	Date         *time.Time `json:"date"`
+	TaskType     string     `json:"task_type"`
+	Status       string     `json:"status"`
+	Hours        float64    `json:"hours"`
+	ProofOfWorks string     `json:"proof_of_works"`
+}
+
+// TimesheetWeeklySummary represents aggregated weekly timesheet data
+type TimesheetWeeklySummary struct {
+	StartDate  time.Time          `json:"start_date"`
+	EndDate    time.Time          `json:"end_date"`
+	TotalHours float64            `json:"total_hours"`
+	ByTaskType map[string]float64 `json:"by_task_type"`
+	ByProject  map[string]float64 `json:"by_project"`
+	EntryCount int                `json:"entry_count"`
+}
+
+// ToTimesheetEntry converts a notion TimesheetEntry to view TimesheetEntry
+func ToTimesheetEntry(e notionSvc.TimesheetEntry) TimesheetEntry {
+	return TimesheetEntry{
+		PageID:       e.PageID,
+		ProjectID:    e.ProjectID,
+		ProjectName:  e.ProjectName,
+		Discord:      e.Discord,
+		Date:         e.Date,
+		TaskType:     e.TaskType,
+		Status:       e.Status,
+		Hours:        e.Hours,
+		ProofOfWorks: e.ProofOfWorks,
+	}
+}
+
+// ToTimesheetEntries converts a slice of notion TimesheetEntry to view TimesheetEntry
+func ToTimesheetEntries(entries []notionSvc.TimesheetEntry) []TimesheetEntry {
+	result := make([]TimesheetEntry, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, ToTimesheetEntry(e))
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

Add REST API endpoints to allow the `fortress-discord` bot to interact with the Notion timesheet database for logging and viewing work hours.

### New Endpoints
- `POST /api/v1/timesheets` - Log timesheet hours (create entry in Notion)
- `GET /api/v1/timesheets` - Get entries by Discord ID with optional date filtering
- `GET /api/v1/timesheets/weekly-summary` - Get weekly hours summary with aggregation

### Files Added
- `pkg/service/notion/timesheet.go` - Notion timesheet service with CRUD operations
- `pkg/handler/timesheet/` - Handler package (interface, implementation, request models, errors)
- `pkg/view/timesheet.go` - Response models and conversion functions
- `pkg/handler/timesheet/timesheet_test.go` - Unit tests

### Files Modified
- `pkg/config/config.go` - Added `NOTION_TIMESHEET_DB_ID` config
- `pkg/handler/handler.go` - Registered Timesheet handler
- `pkg/routes/v1.go` - Added `/timesheets` route group

## Configuration Required

New environment variable needed:
- `NOTION_TIMESHEET_DB_ID` - The Notion database ID for the timesheet database

## Test plan
- [x] Unit tests pass (`go test ./pkg/handler/timesheet/...`)
- [ ] Manual testing with actual Notion database
- [ ] Integration testing with fortress-discord bot