### PR TITLE
fix(employee): use latest payout for check-in

### DIFF
--- a/pkg/handler/employee/office_checkin_eligibility.go
+++ b/pkg/handler/employee/office_checkin_eligibility.go
@@ -4,10 +4,10 @@ import "time"
 
 const officeCheckInEligibilityWindowDays = 45
 
-func isEligibleByFirstPayout(firstPayoutDate *time.Time, cutoff time.Time) bool {
-	if firstPayoutDate == nil {
+func isEligibleByLatestPayout(latestPayoutDate *time.Time, cutoff time.Time) bool {
+	if latestPayoutDate == nil {
 		return false
 	}
 
-	return !firstPayoutDate.Before(cutoff)
+	return !latestPayoutDate.Before(cutoff)
 }

--- a/pkg/handler/employee/office_checkin_eligibility_test.go
+++ b/pkg/handler/employee/office_checkin_eligibility_test.go
@@ -7,25 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsEligibleByFirstPayout(t *testing.T) {
+func TestIsEligibleByLatestPayout(t *testing.T) {
 	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	t.Run("nil_first_payout", func(t *testing.T) {
-		require.False(t, isEligibleByFirstPayout(nil, cutoff))
+	t.Run("nil_latest_payout", func(t *testing.T) {
+		require.False(t, isEligibleByLatestPayout(nil, cutoff))
 	})
 
 	t.Run("before_cutoff", func(t *testing.T) {
 		date := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
-		require.False(t, isEligibleByFirstPayout(&date, cutoff))
+		require.False(t, isEligibleByLatestPayout(&date, cutoff))
 	})
 
 	t.Run("on_cutoff", func(t *testing.T) {
 		date := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		require.True(t, isEligibleByFirstPayout(&date, cutoff))
+		require.True(t, isEligibleByLatestPayout(&date, cutoff))
 	})
 
 	t.Run("after_cutoff", func(t *testing.T) {
 		date := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
-		require.True(t, isEligibleByFirstPayout(&date, cutoff))
+		require.True(t, isEligibleByLatestPayout(&date, cutoff))
 	})
 }

--- a/pkg/service/notion/contractor_payouts.go
+++ b/pkg/service/notion/contractor_payouts.go
@@ -219,9 +219,9 @@ func (s *ContractorPayoutsService) QueryPendingPayoutsByContractor(ctx context.C
 	return payouts, nil
 }
 
-// GetFirstPayoutDateByDiscord returns the earliest payout Date for a contractor identified by Discord username.
+// GetLatestPayoutDateByDiscord returns the most recent payout Date for a contractor identified by Discord username.
 // It returns nil if no payout exists with a Date.
-func (s *ContractorPayoutsService) GetFirstPayoutDateByDiscord(ctx context.Context, discord string) (*time.Time, error) {
+func (s *ContractorPayoutsService) GetLatestPayoutDateByDiscord(ctx context.Context, discord string) (*time.Time, error) {
 	if discord == "" {
 		return nil, errors.New("discord username is required")
 	}
@@ -231,7 +231,7 @@ func (s *ContractorPayoutsService) GetFirstPayoutDateByDiscord(ctx context.Conte
 		return nil, errors.New("contractor payouts database ID not configured")
 	}
 
-	s.logger.Debug(fmt.Sprintf("[DEBUG] contractor_payouts: querying first payout date for discord=%s", discord))
+	s.logger.Debug(fmt.Sprintf("[DEBUG] contractor_payouts: querying latest payout date for discord=%s", discord))
 
 	query := &nt.DatabaseQuery{
 		Filter: &nt.DatabaseQueryFilter{
@@ -261,15 +261,15 @@ func (s *ContractorPayoutsService) GetFirstPayoutDateByDiscord(ctx context.Conte
 		Sorts: []nt.DatabaseQuerySort{
 			{
 				Property:  "Date",
-				Direction: nt.SortDirAsc,
+				Direction: nt.SortDirDesc,
 			},
 		},
-		PageSize: 5,
+		PageSize: 1,
 	}
 
 	resp, err := s.client.QueryDatabase(ctx, payoutsDBID, query)
 	if err != nil {
-		s.logger.Error(err, fmt.Sprintf("[DEBUG] contractor_payouts: failed to query first payout date for discord=%s", discord))
+		s.logger.Error(err, fmt.Sprintf("[DEBUG] contractor_payouts: failed to query latest payout date for discord=%s", discord))
 		return nil, fmt.Errorf("failed to query contractor payouts database: %w", err)
 	}
 
@@ -280,7 +280,7 @@ func (s *ContractorPayoutsService) GetFirstPayoutDateByDiscord(ctx context.Conte
 		}
 
 		if date := s.extractDate(props, "Date"); date != nil {
-			s.logger.Debug(fmt.Sprintf("[DEBUG] contractor_payouts: first payout date found discord=%s date=%s", discord, date.Format("2006-01-02")))
+			s.logger.Debug(fmt.Sprintf("[DEBUG] contractor_payouts: latest payout date found discord=%s date=%s", discord, date.Format("2006-01-02")))
 			return date, nil
 		}
 	}

--- a/pkg/service/notion/contractor_payouts_test.go
+++ b/pkg/service/notion/contractor_payouts_test.go
@@ -40,6 +40,7 @@ func TestGetLatestPayoutDateByDiscord_QueryAndParse(t *testing.T) {
 	require.NoError(t, err)
 	olderDt, err := nt.ParseDateTime("2025-09-30")
 	require.NoError(t, err)
+	oldestDate := time.Date(2025, 9, 30, 0, 0, 0, 0, time.UTC)
 
 	client := newNotionTestClient(t, func(r *http.Request) (*http.Response, error) {
 		require.Equal(t, http.MethodPost, r.Method)
@@ -68,7 +69,7 @@ func TestGetLatestPayoutDateByDiscord_QueryAndParse(t *testing.T) {
 		require.Len(t, query.Sorts, 1)
 		require.Equal(t, "Date", query.Sorts[0].Property)
 		require.Equal(t, nt.SortDirDesc, query.Sorts[0].Direction)
-		require.Equal(t, 1, query.PageSize)
+		require.Equal(t, 5, query.PageSize)
 
 		resp := nt.DatabaseQueryResponse{
 			Results: []nt.Page{
@@ -80,7 +81,7 @@ func TestGetLatestPayoutDateByDiscord_QueryAndParse(t *testing.T) {
 					},
 					Properties: nt.DatabasePageProperties{
 						"Date": nt.DatabasePageProperty{
-							Date: &nt.Date{Start: latestDt},
+							Date: &nt.Date{Start: olderDt},
 						},
 					},
 				},
@@ -92,7 +93,7 @@ func TestGetLatestPayoutDateByDiscord_QueryAndParse(t *testing.T) {
 					},
 					Properties: nt.DatabasePageProperties{
 						"Date": nt.DatabasePageProperty{
-							Date: &nt.Date{Start: olderDt},
+							Date: &nt.Date{Start: latestDt},
 						},
 					},
 				},
@@ -125,6 +126,7 @@ func TestGetLatestPayoutDateByDiscord_QueryAndParse(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.True(t, got.Equal(wantDate))
+	require.NotEqual(t, oldestDate, *got)
 }
 
 func TestGetLatestPayoutDateByDiscord_NoResults(t *testing.T) {


### PR DESCRIPTION
## Summary
- select latest payout date (not first) for office check-in eligibility
- update Notion payout query to scan list and choose max date
- expand Notion test to ensure older-first list still returns latest date

## Testing
- go test ./pkg/service/notion -run TestGetLatestPayoutDateByDiscord