### PR TITLE
feat: accept discord_username from caller for office check-in

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,16 +26,16 @@ linters:
     # - revive
 
   settings:
-    misspell:
-      locale: US
-      ignore-words:
-        - cancelled
-        - Cancelled
     lll:
       line-length: 140
 
   exclusions:
     rules:
+      # Allow British spelling (cancelled/Cancelled) — misspell flags these as US-only
+      - linters:
+          - misspell
+        text: "cancelled"
+
       # Exclude some `staticcheck` messages.
       - linters:
           - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
   settings:
     misspell:
       locale: US
-      ignore:
+      ignore-words:
         - cancelled
         - Cancelled
     lll:

--- a/pkg/controller/employee/checkin.go
+++ b/pkg/controller/employee/checkin.go
@@ -19,16 +19,17 @@ type CheckinResponse struct {
 	TransactionHash string
 }
 
-func (r *controller) CheckIn(discordID string, t time.Time, amount float64) (*CheckinResponse, error) {
+func (r *controller) CheckIn(discordID string, discordUsername string, t time.Time, amount float64) (*CheckinResponse, error) {
 	l := r.logger.Fields(logger.Fields{
 		"controller": "employee",
 		"method":     "CheckIn",
 	})
 
-	// Get employee by discord id
-	employee, err := r.store.Employee.GetByDiscordID(r.repo.DB(), discordID, true)
+	// Get employee by discord username (resolved from Discord by the caller)
+	// instead of discord_id, which may be stale in our DB.
+	employee, err := r.store.Employee.GetByDiscordUsername(r.repo.DB(), discordUsername)
 	if err != nil {
-		l.Error(err, "failed to get employee by discord id")
+		l.Error(err, "failed to get employee by discord username")
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrEmployeeNotFound
 		}

--- a/pkg/controller/employee/new.go
+++ b/pkg/controller/employee/new.go
@@ -50,5 +50,5 @@ type IController interface {
 	GetEmployeeEarnTransactions(discordID string, input GetEmployeeEarnTransactionsInput) (model.EmployeeEarnTransactions, int64, error)
 	GetEmployeeTotalEarn(discordID string) (string, string, error)
 	GetTotalEarn(from, to time.Time) (string, string, error)
-	CheckIn(discordID string, t time.Time, amount float64) (*CheckinResponse, error)
+	CheckIn(discordID string, discordUsername string, t time.Time, amount float64) (*CheckinResponse, error)
 }

--- a/pkg/handler/employee/employee.go
+++ b/pkg/handler/employee/employee.go
@@ -1227,25 +1227,16 @@ func (h *handler) OfficeCheckIn(c *gin.Context) {
 			DiscordID: v.DiscordID,
 		}
 
-		discordUsername, ok := discordUsernameCache[v.DiscordID]
-		if !ok {
-			account, err := h.store.DiscordAccount.OneByDiscordID(h.repo.DB(), v.DiscordID)
-			if err != nil {
-				l.Error(err, "failed to get discord account by discord id")
-				data.Err = "discord account not found"
-				resp = append(resp, data)
-				continue
-			}
-
-			discordUsername = account.DiscordUsername
-			if discordUsername == "" {
-				data.Err = "discord username not found"
-				resp = append(resp, data)
-				continue
-			}
-
-			discordUsernameCache[v.DiscordID] = discordUsername
+		// Use the discord_username provided by the caller (resolved from Discord directly)
+		// instead of looking it up from our DB, which may have stale discord_id → username mappings.
+		discordUsername := v.DiscordUsername
+		if discordUsername == "" {
+			data.Err = "discord username not found"
+			resp = append(resp, data)
+			continue
 		}
+
+		discordUsernameCache[v.DiscordID] = discordUsername
 
 		latestPayoutDate, ok := latestPayoutDateCache[discordUsername]
 		if !ok {
@@ -1267,7 +1258,7 @@ func (h *handler) OfficeCheckIn(c *gin.Context) {
 			continue
 		}
 
-		r, err := h.controller.Employee.CheckIn(v.DiscordID, v.Time, float64(icyAmount))
+		r, err := h.controller.Employee.CheckIn(v.DiscordID, v.DiscordUsername, v.Time, float64(icyAmount))
 		if err != nil {
 			l.Error(err, "failed to checkin")
 			data.Err = err.Error()

--- a/pkg/handler/employee/request/request.go
+++ b/pkg/handler/employee/request/request.go
@@ -274,6 +274,7 @@ type CheckInRequest struct {
 } // @name CheckInRequest
 
 type CheckIn struct {
-	DiscordID string    `json:"discord_id" binding:"required"`
-	Time      time.Time `json:"time" binding:"required"`
+	DiscordID       string    `json:"discord_id" binding:"required"`
+	DiscordUsername string    `json:"discord_username" binding:"required"`
+	Time            time.Time `json:"time" binding:"required"`
 }

--- a/pkg/routes/v1_test.go
+++ b/pkg/routes/v1_test.go
@@ -720,6 +720,30 @@ func Test_loadV1Routes(t *testing.T) {
 				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/discord.IHandler.PostGolangNews-fm",
 			},
 		},
+		"/api/v1/notify/extra-payment/preview": {
+			"POST": {
+				Method:  "POST",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/notify.IHandler.PreviewExtraPaymentNotification-fm",
+			},
+		},
+		"/api/v1/notify/extra-payment/send": {
+			"POST": {
+				Method:  "POST",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/notify.IHandler.SendExtraPaymentNotification-fm",
+			},
+		},
+		"/api/v1/notify/extra-payment/send-one": {
+			"POST": {
+				Method:  "POST",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/notify.IHandler.SendOneExtraPaymentNotification-fm",
+			},
+		},
+		"/api/v1/work-updates/:month": {
+			"GET": {
+				Method:  "GET",
+				Handler: "github.com/dwarvesf/fortress-api/pkg/handler/workupdates.IHandler.GetWorkUpdates-fm",
+			},
+		},
 		"/webhooks/n8n": {
 			"POST": {
 				Method:  "POST",


### PR DESCRIPTION
## Problem

The `discord_accounts` table has stale `discord_id` values from seed data. For example, nhuthm has placeholder `100000000000000019` instead of the real `797***`. The `SyncDiscordInfo` cronjob upserts by `discord_id`, creating a second row with the real ID but never updating the employee `discord_account_id` FK. This causes `GetByDiscordID` to fail and prevents ICY distribution on office check-in.

## Solution

The office-checkin bot now sends `discord_username` (resolved from Discord at gm-time) alongside `discord_id`. This PR updates the fortress API to:

1. **`CheckIn` request** — add `discord_username` field (required)
2. **`OfficeCheckIn` handler** — use the provided `discord_username` directly instead of looking it up via `OneByDiscordID`
3. **`CheckIn` controller** — call `GetByDiscordUsername` instead of `GetByDiscordID` to find the employee

The real `discord_id` is still passed through for Mochi transfers.

## Changes

- `pkg/handler/employee/request/request.go` — add `DiscordUsername` to `CheckIn` struct
- `pkg/handler/employee/employee.go` — replace `OneByDiscordID` DB lookup with using `v.DiscordUsername` from request
- `pkg/controller/employee/new.go` — update `IController.CheckIn` signature
- `pkg/controller/employee/checkin.go` — use `GetByDiscordUsername` instead of `GetByDiscordID`

## Companion PR

- office-checkin: `54d329a` — passes `discord_username` from Discord through the check-in flow