### PR TITLE
fix(leave): query pending by status=New + resolve button page ids directly

### DIFF
--- a/pkg/handler/webhook/leave_decision.go
+++ b/pkg/handler/webhook/leave_decision.go
@@ -114,25 +114,47 @@ func (h *handler) discordHandleForEmail(l logger.Logger, email string) string {
 // human title (from the DM tool, e.g. OOO-2026-innno_-HGU4) or the Notion page id (from a button's
 // custom_id). Both front-ends converge here. Returns ok=false when no pending request matches.
 func (h *handler) findPendingLeave(ctx context.Context, leaveService *notionSvc.LeaveService, requestID string) (notionSvc.LeaveRequest, bool, error) {
+	want := strings.TrimSpace(requestID)
+
+	// A page id (button path) resolves directly, no list query needed. Only a still-New request is
+	// actionable; an already-decided one is treated as "not pending" so approve/reject 404s cleanly.
+	if looksLikeNotionPageID(want) {
+		lr, err := leaveService.GetLeaveRequest(ctx, want)
+		if err != nil || lr == nil {
+			return notionSvc.LeaveRequest{}, false, nil
+		}
+		if isLeaveAlreadyDecided(lr.Status) {
+			return notionSvc.LeaveRequest{}, false, nil
+		}
+		return *lr, true, nil
+	}
+
+	// A title (DM path) needs the pending list to match against.
 	pending, err := leaveService.QueryPendingLeaveRequests(ctx)
 	if err != nil {
 		return notionSvc.LeaveRequest{}, false, err
 	}
-	want := strings.TrimSpace(requestID)
 	for _, lr := range pending {
-		if leaveTitleMatches(lr.LeaveRequestTitle, requestID) || leavePageIDMatches(lr.PageID, want) {
+		if leaveTitleMatches(lr.LeaveRequestTitle, requestID) {
 			return lr, true, nil
 		}
 	}
 	return notionSvc.LeaveRequest{}, false, nil
 }
 
-// leavePageIDMatches compares a Notion page id ignoring dash formatting (the API returns dashed
-// UUIDs; a button custom_id may carry the undashed form).
-func leavePageIDMatches(candidate, requestID string) bool {
-	strip := func(s string) string { return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), "-", "")) }
-	c := strip(candidate)
-	return c != "" && c == strip(requestID)
+// looksLikeNotionPageID reports whether s is a Notion page id (32 hex chars, dashed or not) rather
+// than a human leave title.
+func looksLikeNotionPageID(s string) bool {
+	stripped := strings.ReplaceAll(s, "-", "")
+	if len(stripped) != 32 {
+		return false
+	}
+	for _, r := range stripped {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 // leaveTitleMatches compares a candidate leave title against a requested id, tolerant of

--- a/pkg/handler/webhook/leave_decision_test.go
+++ b/pkg/handler/webhook/leave_decision_test.go
@@ -76,21 +76,23 @@ func TestIsLeaveAlreadyDecided(t *testing.T) {
 	}
 }
 
-// A button carries the Notion page id; the DM carries the title. Both must resolve, and dash
-// formatting on the page id must not matter.
-func TestLeavePageIDMatches(t *testing.T) {
+// A button carries the Notion page id (32 hex, dashed or not); a DM carries the human title.
+// findPendingLeave routes on this: a page id resolves directly, a title goes through the list.
+func TestLooksLikeNotionPageID(t *testing.T) {
 	cases := []struct {
-		candidate, requestID string
-		want                 bool
+		in   string
+		want bool
 	}{
-		{"3a564b29-b84c-81a6-bd55-fa785e0c3b1d", "3a564b29-b84c-81a6-bd55-fa785e0c3b1d", true},
-		{"3a564b29-b84c-81a6-bd55-fa785e0c3b1d", "3a564b29b84c81a6bd55fa785e0c3b1d", true}, // undashed
-		{"3a564b29-b84c-81a6-bd55-fa785e0c3b1d", "OOO-2026-innno_-HGU4", false},            // a title, not a page id
-		{"", "", false}, // empty page id never matches
+		{"3a564b29-b84c-81a6-bd55-fa785e0c3b1d", true}, // dashed uuid
+		{"3a564b29b84c81a6bd55fa785e0c3b1d", true},     // undashed
+		{"OOO-2026-innno_-HGU4", false},                // a title
+		{"", false},
+		{"3a564b29-b84c-81a6-bd55-fa785e0c3b1", false}, // 31 hex, too short
+		{"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", false},    // 32 non-hex
 	}
 	for _, c := range cases {
-		if got := leavePageIDMatches(c.candidate, c.requestID); got != c.want {
-			t.Errorf("leavePageIDMatches(%q,%q) = %v, want %v", c.candidate, c.requestID, got, c.want)
+		if got := looksLikeNotionPageID(c.in); got != c.want {
+			t.Errorf("looksLikeNotionPageID(%q) = %v, want %v", c.in, got, c.want)
 		}
 	}
 }

--- a/pkg/service/notion/leave.go
+++ b/pkg/service/notion/leave.go
@@ -83,7 +83,7 @@ func (s *LeaveService) GetLeaveRequest(ctx context.Context, pageID string) (*Lea
 		LeaveRequestTitle:  ExtractTitle(props, "Leave Request"),
 		UnavailabilityType: ExtractSelect(props, "Unavailability Type"),
 		AdditionalContext:  ExtractRichText(props, "Additional Context"),
-		Status:             ExtractSelect(props, "Status"),
+		Status:             ExtractStatus(props, "Status"),
 	}
 
 	// Extract dates
@@ -188,12 +188,13 @@ func (s *LeaveService) QueryPendingLeaveRequests(ctx context.Context) ([]LeaveRe
 
 	s.logger.Debug(fmt.Sprintf("querying pending leave requests from data source: %s", dataSourceID))
 
-	// Query for pending leave requests
+	// Query for pending leave requests. The "Status" property is a Notion STATUS type (not select),
+	// and a not-yet-decided request is "New" (Acknowledged / Not Applicable / Withdrawn are decided).
 	filter := &nt.DatabaseQueryFilter{
 		Property: "Status",
 		DatabaseQueryPropertyFilter: nt.DatabaseQueryPropertyFilter{
-			Select: &nt.SelectDatabaseQueryFilter{
-				Equals: "Pending",
+			Status: &nt.StatusDatabaseQueryFilter{
+				Equals: "New",
 			},
 		},
 	}
@@ -216,7 +217,7 @@ func (s *LeaveService) QueryPendingLeaveRequests(ctx context.Context) ([]LeaveRe
 			LeaveRequestTitle:  ExtractTitle(props, "Leave Request"),
 			UnavailabilityType: ExtractSelect(props, "Unavailability Type"),
 			AdditionalContext:  ExtractRichText(props, "Additional Context"),
-			Status:             ExtractSelect(props, "Status"),
+			Status:             ExtractStatus(props, "Status"),
 			StartDate:          ExtractDate(props, "Start Date"),
 			EndDate:            ExtractDate(props, "End Date"),
 			Email:              ExtractEmail(props, "Team Email"),


### PR DESCRIPTION
QueryPendingLeaveRequests used a select filter for 'Pending'; Status is a STATUS type and pending is 'New' (Notion 400'd it). Fix the filter + ExtractStatus + resolve button page-ids via GetLeaveRequest directly. Follows #809.