### PR TITLE
fix(leave): serialize decisions per page + scope the button page-id path

### DIFF
--- a/pkg/handler/webhook/leave_decision.go
+++ b/pkg/handler/webhook/leave_decision.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 
@@ -123,6 +124,12 @@ func (h *handler) findPendingLeave(ctx context.Context, leaveService *notionSvc.
 		if err != nil || lr == nil {
 			return notionSvc.LeaveRequest{}, false, nil
 		}
+		// Scope check: GetLeaveRequest fetches ANY page the integration can read, so confirm this
+		// page is actually a leave request (its title has the OOO-/LVR- shape) before we act on it.
+		// Otherwise a 32-hex request_id could point a decision at an unrelated page.
+		if !isLeaveRequestTitle(lr.LeaveRequestTitle) {
+			return notionSvc.LeaveRequest{}, false, nil
+		}
 		if isLeaveAlreadyDecided(lr.Status) {
 			return notionSvc.LeaveRequest{}, false, nil
 		}
@@ -163,6 +170,13 @@ func leaveTitleMatches(candidate, requestID string) bool {
 	return strings.EqualFold(strings.TrimSpace(candidate), strings.TrimSpace(requestID))
 }
 
+// isLeaveRequestTitle reports whether a title has the leave-request shape (OOO-... or LVR-...),
+// used to confirm a page resolved by id is actually a leave request and not an arbitrary page.
+func isLeaveRequestTitle(title string) bool {
+	t := strings.ToUpper(strings.TrimSpace(title))
+	return strings.HasPrefix(t, "OOO-") || strings.HasPrefix(t, "LVR-")
+}
+
 // isLeaveAlreadyDecided reports whether a leave request has already been acted on, so a repeat or
 // concurrent decision does not re-run the calendar side effect (SPEC-087 edge case 2).
 func isLeaveAlreadyDecided(status string) bool {
@@ -174,11 +188,29 @@ func isLeaveAlreadyDecided(status string) bool {
 	}
 }
 
+// leaveDecisionLocks serializes decisions per leave page id. The idempotency guard is a
+// read-status-then-write, which without a lock has a TOCTOU window: two near-simultaneous
+// approvals of the same request (a lead double-tapping the button) could both read Status=New
+// before either writes, and both create a calendar event. Locking per page id closes that window.
+// The api deployment is a single replica, so an in-process lock is sufficient; a multi-replica
+// deployment would additionally need a Notion conditional update (write only if Status is New).
+var leaveDecisionLocks sync.Map // pageID -> *sync.Mutex
+
+func lockLeaveDecision(pageID string) func() {
+	m, _ := leaveDecisionLocks.LoadOrStore(pageID, &sync.Mutex{})
+	mu := m.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 // applyLeaveDecision is the side-effect core shared by the endpoints (the button handlers keep
 // their own inline copy for now). "approve" -> Status Acknowledged + a calendar event; "reject" ->
 // Status Not Applicable, no calendar. Idempotent: if the request is already decided, it does NOT
 // re-create the calendar event, so two near-simultaneous approvals cannot double-book (edge case 2).
 func (h *handler) applyLeaveDecision(ctx context.Context, l logger.Logger, leaveService *notionSvc.LeaveService, pageID, approverPageID, decision string) {
+	unlock := lockLeaveDecision(pageID)
+	defer unlock()
+
 	// Idempotency guard: read current status first; skip the calendar side effect if already decided.
 	alreadyDecided := false
 	if cur, err := leaveService.GetLeaveRequest(ctx, pageID); err == nil && cur != nil {

--- a/pkg/handler/webhook/leave_decision_test.go
+++ b/pkg/handler/webhook/leave_decision_test.go
@@ -1,6 +1,9 @@
 package webhook
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // normalizeHandle is the security-critical comparison for leave approval: the caller's handle
 // (from the gateway token) is matched against the AM/DL set (from the Notion "Discord" field). A
@@ -94,5 +97,49 @@ func TestLooksLikeNotionPageID(t *testing.T) {
 		if got := looksLikeNotionPageID(c.in); got != c.want {
 			t.Errorf("looksLikeNotionPageID(%q) = %v, want %v", c.in, got, c.want)
 		}
+	}
+}
+
+// isLeaveRequestTitle scopes the button page-id path to real leave requests.
+func TestIsLeaveRequestTitle(t *testing.T) {
+	yes := []string{"OOO-2026-innno_-HGU4", "ooo-2026-x-Y", "LVR-2025-taipn-29DQ", "  OOO-2026-- "}
+	no := []string{"", "Some Random Page", "Meeting notes", "2026-07-22"}
+	for _, s := range yes {
+		if !isLeaveRequestTitle(s) {
+			t.Errorf("%q should be a leave title", s)
+		}
+	}
+	for _, s := range no {
+		if isLeaveRequestTitle(s) {
+			t.Errorf("%q should NOT be a leave title", s)
+		}
+	}
+}
+
+// lockLeaveDecision serializes per page id: the same id returns a lock that blocks a second caller
+// until released; different ids do not block each other.
+func TestLockLeaveDecision(t *testing.T) {
+	unlock := lockLeaveDecision("page-A")
+	// A different page must not be blocked by page-A's lock.
+	done := make(chan struct{})
+	go func() { u := lockLeaveDecision("page-B"); u(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("a different page id must not block")
+	}
+	// The same page id must block until the first unlock.
+	blocked := make(chan struct{})
+	go func() { u := lockLeaveDecision("page-A"); u(); close(blocked) }()
+	select {
+	case <-blocked:
+		t.Fatal("same page id must block while held")
+	case <-time.After(100 * time.Millisecond):
+	}
+	unlock()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("second caller should proceed after unlock")
 	}
 }


### PR DESCRIPTION
Security-review follow-ups: per-page-id lock closes the idempotency race (single-replica); scope the button page-id resolution to leave-shaped pages. Follows #810.