### PR TITLE
fix(invoice): refuse a non-USD payout when conversion fails

### DIFF
--- a/pkg/controller/invoice/contractor_invoice.go
+++ b/pkg/controller/invoice/contractor_invoice.go
@@ -454,6 +454,10 @@ func (c *controller) GenerateContractorInvoice(ctx context.Context, discord, mon
 	var convWg sync.WaitGroup
 	var convMu sync.Mutex
 	var capturedDisplayRate float64
+	// First conversion failure on a NON-USD payout. Recorded rather than
+	// swallowed, and checked after the WaitGroup, so one bad payout refuses the
+	// whole invoice instead of quietly contributing a wrong line to it.
+	var convErr error
 
 	for i, payout := range payouts {
 		convWg.Add(1)
@@ -464,8 +468,22 @@ func (c *controller) GenerateContractorInvoice(ctx context.Context, discord, mon
 			if err != nil {
 				convMu.Lock()
 				l.Error(err, fmt.Sprintf("failed to resolve payout amount to USD: pageID=%s", p.PageID))
+				// Falling back to the raw amount is only safe when the payout is
+				// ALREADY in USD. For any other currency it assigns the local
+				// figure straight to the dollar field, so a 26,000,000 VND payout
+				// becomes a $26,000,000 invoice line, and it does so precisely
+				// when Wise or Redis is down, which is when nobody is watching.
+				// Refuse instead: an invoice that fails to generate is a support
+				// ticket, an invoice with a 1000x line is a payment.
+				if cur := strings.ToUpper(strings.TrimSpace(p.Currency)); cur != "" && cur != "USD" {
+					if convErr == nil {
+						convErr = fmt.Errorf("refusing to invoice payout %s: cannot convert %s to USD: %w", p.PageID, cur, err)
+					}
+					convMu.Unlock()
+					return
+				}
 				convMu.Unlock()
-				amountUSD = p.Amount // Fallback to original amount if conversion fails
+				amountUSD = p.Amount
 			}
 			// ResolveAmountUSD already rounds to 2 decimal places, but we ensure it's assigned correctly
 			amountsUSD[idx] = amountUSD
@@ -480,6 +498,9 @@ func (c *controller) GenerateContractorInvoice(ctx context.Context, discord, mon
 	}
 
 	convWg.Wait()
+	if convErr != nil {
+		return nil, convErr
+	}
 	l.Debug("[DEBUG] contractor_invoice: parallel currency conversions completed")
 
 	// Create task order service for hourly rate processing


### PR DESCRIPTION
`contractor_invoice.go:463-469` fell back to `amountUSD = p.Amount` whenever `ResolveAmountUSD` errored. For a non-USD payout that assigns the **raw local figure to the dollar field**: a 26,000,000 VND payout becomes a **$26,000,000** invoice line. It fails **open**, and it fails precisely when Wise or Redis is down.

**Not theoretical:** the Contractor Payouts database currently holds **393 VND rows against 420 USD**. Roughly half of all payouts take this path on every run.

The fallback is kept where it is harmless (a payout already in USD, where the raw amount *is* the dollar amount) and refused everywhere else. The first failure is recorded and checked after the WaitGroup, so one bad payout refuses the whole invoice instead of contributing a wrong line to it.

An invoice that fails to generate is a support ticket. An invoice with a 1000x line is a payment.

Verified: `go build`, `go vet`, and `go test ./pkg/controller/invoice/...` all pass (built with the mise Go 1.24.2 that matches GOROOT, per the repo's known toolchain trap).

Found while porting this pipeline to Cloudflare, where the port refuses the same case rather than inheriting the fallback.

https://claude.ai/code/session_01UgkobZof5By2wCpkBXhjK4